### PR TITLE
[Feat] Lodge: 숙소 정보 생성 API

### DIFF
--- a/lodge/src/main/java/com/haot/lodge/application/response/LodgeResponse.java
+++ b/lodge/src/main/java/com/haot/lodge/application/response/LodgeResponse.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.application.response;
 
 
+import com.haot.lodge.domain.model.Lodge;
 import lombok.Builder;
 
 @Builder
@@ -13,4 +14,15 @@ public record LodgeResponse(
         Integer term,
         Double basicPrice
 ) {
+    public static LodgeResponse from(Lodge lodge) {
+        return new LodgeResponse(
+                lodge.getId(),
+                lodge.getHostId(),
+                lodge.getName(),
+                lodge.getDescription(),
+                lodge.getAddress(),
+                lodge.getTerm(),
+                lodge.getBasicPrice()
+        );
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeBasicService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeBasicService.java
@@ -1,0 +1,32 @@
+package com.haot.lodge.application.service.Impl;
+
+
+import com.haot.lodge.common.exception.ErrorCode;
+import com.haot.lodge.common.exception.LodgeException;
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.repository.LodgeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LodgeService {
+
+    private final LodgeRepository lodgeRepository;
+
+    public Lodge create(
+            String userId,
+            String name,
+            String description,
+            String address,
+            Integer term,
+            Double basicPrice
+    ) {
+        if(lodgeRepository.findByHostIdAndName(userId, name).isPresent()) {
+            throw new LodgeException(ErrorCode.ALREADY_EXIST_REVIEW);
+        }
+        return Lodge.createLodge(
+                userId, name, description, address, term, basicPrice
+        );
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeBasicService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeBasicService.java
@@ -7,10 +7,11 @@ import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.repository.LodgeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class LodgeService {
+public class LodgeBasicService {
 
     private final LodgeRepository lodgeRepository;
 
@@ -25,8 +26,8 @@ public class LodgeService {
         if(lodgeRepository.findByHostIdAndName(userId, name).isPresent()) {
             throw new LodgeException(ErrorCode.ALREADY_EXIST_REVIEW);
         }
-        return Lodge.createLodge(
+        return lodgeRepository.save(Lodge.createLodge(
                 userId, name, description, address, term, basicPrice
-        );
+        ));
     }
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeDateService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeDateService.java
@@ -1,0 +1,70 @@
+package com.haot.lodge.application.service;
+
+
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeDate;
+import com.haot.lodge.domain.model.enums.ReservationStatus;
+import com.haot.lodge.domain.repository.LodgeDateRepository;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LodgeDateService {
+
+    private final LodgeDateRepository lodgeDateRepository;
+    private final Integer MIN_RANGE = 30;
+    private final Integer MAX_RANGE = 365;
+
+
+    @Transactional
+    public void create(
+            Lodge lodge, LocalDate startDate, LocalDate endDate, List<LocalDate> excludeDates
+    ) {
+        dateValidation(startDate, endDate);
+        Set<LocalDate> excludeDateSet = excludeDates != null
+                ? new HashSet<>(excludeDates)
+                : Collections.emptySet();
+        List<LodgeDate> lodgeDates = new ArrayList<>();
+        LocalDate currentDate = startDate;
+        while (!currentDate.isAfter(endDate)) {
+            ReservationStatus status = excludeDateSet.contains(currentDate)
+                    ? ReservationStatus.UNSELECTABLE
+                    : ReservationStatus.WAITING;
+            LodgeDate lodgeDate = LodgeDate.create(lodge, currentDate, lodge.getBasicPrice(), status);
+            lodgeDates.add(lodgeDate);
+            currentDate = currentDate.plusDays(1);
+        }
+
+        lodgeDateRepository.saveAll(lodgeDates);
+    }
+
+    /**
+     * 입력된 날짜 유효성 검사
+     * @param startDate 숙소 시작 날짜
+     * @param endDate 숙소 끝 날짜
+     */
+    private void dateValidation(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isBefore(LocalDate.now())) {
+            throw new IllegalArgumentException("Start date must be before or equal to end date.");
+        }
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("Start date must be before or equal to end date.");
+        }
+        long daysBetween = ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        if (daysBetween < MIN_RANGE) {
+            throw new IllegalArgumentException("The date range must be at least 30 days.");
+        }
+        if (daysBetween > MAX_RANGE) {
+            throw new IllegalArgumentException("The date range cannot exceed 365 days.");
+        }
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeDateService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeDateService.java
@@ -1,6 +1,8 @@
-package com.haot.lodge.application.service;
+package com.haot.lodge.application.service.Impl;
 
 
+import com.haot.lodge.common.exception.ErrorCode;
+import com.haot.lodge.common.exception.LodgeException;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.model.LodgeDate;
 import com.haot.lodge.domain.model.enums.ReservationStatus;
@@ -43,7 +45,6 @@ public class LodgeDateService {
             lodgeDates.add(lodgeDate);
             currentDate = currentDate.plusDays(1);
         }
-
         lodgeDateRepository.saveAll(lodgeDates);
     }
 
@@ -54,17 +55,17 @@ public class LodgeDateService {
      */
     private void dateValidation(LocalDate startDate, LocalDate endDate) {
         if (startDate.isBefore(LocalDate.now())) {
-            throw new IllegalArgumentException("Start date must be before or equal to end date.");
+            throw new LodgeException(ErrorCode.START_DATE_IN_PAST);
         }
         if (startDate.isAfter(endDate)) {
-            throw new IllegalArgumentException("Start date must be before or equal to end date.");
+            throw new LodgeException(ErrorCode.START_DATE_AFTER_END_DATE);
         }
         long daysBetween = ChronoUnit.DAYS.between(startDate, endDate) + 1;
         if (daysBetween < MIN_RANGE) {
-            throw new IllegalArgumentException("The date range must be at least 30 days.");
+            throw new LodgeException(ErrorCode.DATE_RANGE_TOO_SHORT);
         }
         if (daysBetween > MAX_RANGE) {
-            throw new IllegalArgumentException("The date range cannot exceed 365 days.");
+            throw new LodgeException(ErrorCode.DATE_RANGE_TOO_LONG);
         }
     }
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeImageService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeImageService.java
@@ -1,0 +1,28 @@
+package com.haot.lodge.application.service;
+
+
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeImage;
+import com.haot.lodge.domain.repository.LodgeImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class LodgeImageService {
+
+    private final LodgeImageRepository lodgeImageRepository;
+
+    public void create(
+            Lodge lodge, MultipartFile file, String title, String description
+    ) {
+        lodgeImageRepository.save(
+                LodgeImage.create(lodge, convertToUrl(file), title, description)
+        );
+    }
+
+    private String convertToUrl(MultipartFile file) {
+        return "http://S3";
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeImageService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeImageService.java
@@ -1,4 +1,4 @@
-package com.haot.lodge.application.service;
+package com.haot.lodge.application.service.Impl;
 
 
 import com.haot.lodge.domain.model.Lodge;
@@ -22,6 +22,7 @@ public class LodgeImageService {
         );
     }
 
+    // TODO: S3 연결 필요
     private String convertToUrl(MultipartFile file) {
         return "http://S3";
     }

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeRuleService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeRuleService.java
@@ -1,4 +1,4 @@
-package com.haot.lodge.application.service;
+package com.haot.lodge.application.service.Impl;
 
 
 import com.haot.lodge.domain.model.Lodge;

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeRuleService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeRuleService.java
@@ -1,0 +1,25 @@
+package com.haot.lodge.application.service;
+
+
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeRule;
+import com.haot.lodge.domain.repository.LodgeRuleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LodgeRuleService {
+
+    private final LodgeRuleRepository lodgeRuleRepository;
+
+    @Transactional
+    public void create(
+            Lodge linkedLodge, Integer maxReservationDay, Integer maxPersonnel, String customization
+    ) {
+        lodgeRuleRepository.save(
+                LodgeRule.create(linkedLodge, maxReservationDay, maxPersonnel, customization)
+        );
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
@@ -1,0 +1,47 @@
+package com.haot.lodge.application.service;
+
+
+import com.haot.lodge.application.service.Impl.LodgeDateService;
+import com.haot.lodge.application.service.Impl.LodgeImageService;
+import com.haot.lodge.application.service.Impl.LodgeRuleService;
+import com.haot.lodge.application.service.Impl.LodgeService;
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.presentation.request.LodgeCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@org.springframework.stereotype.Service
+@RequiredArgsConstructor
+@Transactional
+public class Service {
+
+    private final LodgeService lodgeService;
+    private final LodgeImageService lodgeImageService;
+    private final LodgeRuleService lodgeRuleService;
+    private final LodgeDateService lodgeDateService;
+
+    @Transactional
+    public void createLodge(String userId, LodgeCreateRequest request) {
+        // TODO: UserId 유효성 검증
+        Lodge lodge = lodgeService.create(
+                userId, request.name(), request.description(), request.address(),
+                request.term(), request.basicPrice());
+        lodgeImageService.create(lodge, request.image(), request.imageTitle(), request.imageDescriptions());
+        lodgeRuleService.create(lodge, request.maxReservationDay(), request.maxPersonnel(), request.customization());
+        lodgeDateService.create(lodge, request.startDate(), request.endDate(), request.excludeDates());
+    }
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
@@ -1,10 +1,11 @@
 package com.haot.lodge.application.service;
 
 
+import com.haot.lodge.application.response.LodgeResponse;
 import com.haot.lodge.application.service.Impl.LodgeDateService;
 import com.haot.lodge.application.service.Impl.LodgeImageService;
 import com.haot.lodge.application.service.Impl.LodgeRuleService;
-import com.haot.lodge.application.service.Impl.LodgeService;
+import com.haot.lodge.application.service.Impl.LodgeBasicService;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.presentation.request.LodgeCreateRequest;
 import lombok.RequiredArgsConstructor;
@@ -13,22 +14,23 @@ import org.springframework.transaction.annotation.Transactional;
 @org.springframework.stereotype.Service
 @RequiredArgsConstructor
 @Transactional
-public class Service {
+public class LodgeService {
 
-    private final LodgeService lodgeService;
+    private final LodgeBasicService lodgeBasicService;
     private final LodgeImageService lodgeImageService;
     private final LodgeRuleService lodgeRuleService;
     private final LodgeDateService lodgeDateService;
 
     @Transactional
-    public void createLodge(String userId, LodgeCreateRequest request) {
+    public LodgeResponse createLodge(String userId, LodgeCreateRequest request) {
         // TODO: UserId 유효성 검증
-        Lodge lodge = lodgeService.create(
+        Lodge lodge = lodgeBasicService.create(
                 userId, request.name(), request.description(), request.address(),
                 request.term(), request.basicPrice());
-        lodgeImageService.create(lodge, request.image(), request.imageTitle(), request.imageDescriptions());
+        lodgeImageService.create(lodge, request.image(), request.imageTitle(), request.imageDescription());
         lodgeRuleService.create(lodge, request.maxReservationDay(), request.maxPersonnel(), request.customization());
         lodgeDateService.create(lodge, request.startDate(), request.endDate(), request.excludeDates());
+        return LodgeResponse.from(lodge);
     }
 
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
@@ -34,16 +34,3 @@ public class LodgeService {
     }
 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/lodge/src/main/java/com/haot/lodge/common/config/ValidationMessageConfig.java
+++ b/lodge/src/main/java/com/haot/lodge/common/config/ValidationMessageConfig.java
@@ -1,0 +1,4 @@
+package com.haot.lodge.common.config;
+
+public class ValidationMessageConfig {
+}

--- a/lodge/src/main/java/com/haot/lodge/common/config/ValidationMessageConfig.java
+++ b/lodge/src/main/java/com/haot/lodge/common/config/ValidationMessageConfig.java
@@ -1,4 +1,18 @@
 package com.haot.lodge.common.config;
 
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+
+
+@Configuration
 public class ValidationMessageConfig {
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:validation-messages-ko");
+        messageSource.setDefaultEncoding("UTF-8");
+        return messageSource;
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
@@ -1,0 +1,4 @@
+package com.haot.lodge.common.exception;
+
+public enum ErrorCode {
+}

--- a/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
@@ -1,4 +1,25 @@
 package com.haot.lodge.common.exception;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
 public enum ErrorCode {
+    // 0000: Common Error
+    VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "0009", "Validation failed"),
+
+    // 5000: Lodge Error
+    ALREADY_EXIST_REVIEW(HttpStatus.CONFLICT, "5001","같은 이름의 숙소가 이미 존재합니다."),
+
+    // 5100: LodgeDate Error
+    START_DATE_IN_PAST(HttpStatus.BAD_REQUEST, "5101", "시작 날짜는 현재 날짜 이후여야 합니다."),
+    START_DATE_AFTER_END_DATE(HttpStatus.BAD_REQUEST, "5102", "시작 날짜는 종료 날짜보다 이전이어야 합니다."),
+    DATE_RANGE_TOO_SHORT(HttpStatus.BAD_REQUEST, "5103", "날짜 범위는 최소 30일 이상이어야 합니다."),
+    DATE_RANGE_TOO_LONG(HttpStatus.BAD_REQUEST, "5104", "날짜 범위는 최대 365일을 초과할 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/lodge/src/main/java/com/haot/lodge/common/exception/GlobalControllerAdvice.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/GlobalControllerAdvice.java
@@ -1,0 +1,4 @@
+package com.haot.lodge.common.exception;
+
+public class GlobalControllerAdvice {
+}

--- a/lodge/src/main/java/com/haot/lodge/common/exception/GlobalControllerAdvice.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/GlobalControllerAdvice.java
@@ -1,4 +1,39 @@
 package com.haot.lodge.common.exception;
 
+
+import com.haot.lodge.common.response.ApiResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j(topic = "ExceptionHandler")
+@RestControllerAdvice
 public class GlobalControllerAdvice {
+
+    @Order(0)
+    @ExceptionHandler(LodgeException.class)
+    public ResponseEntity<ApiResponse<Void>> applicationException(final LodgeException e){
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.fail(e.getErrorCode()));
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        List<String> errors = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + " : " + error.getDefaultMessage())
+                .collect(Collectors.toList());
+        return ApiResponse.fail(ErrorCode.VALIDATION_EXCEPTION, errors);
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/common/exception/LodgeException.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/LodgeException.java
@@ -1,0 +1,7 @@
+package com.haot.lodge.common.exception;
+
+public class LodgeException extends RuntimeException {
+  public LodgeException(String message) {
+    super(message);
+  }
+}

--- a/lodge/src/main/java/com/haot/lodge/common/exception/LodgeException.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/LodgeException.java
@@ -1,7 +1,12 @@
 package com.haot.lodge.common.exception;
 
+import lombok.Getter;
+
+@Getter
 public class LodgeException extends RuntimeException {
-  public LodgeException(String message) {
-    super(message);
-  }
+    private final ErrorCode errorCode;
+
+    public LodgeException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/common/response/ApiResponse.java
+++ b/lodge/src/main/java/com/haot/lodge/common/response/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.haot.lodge.common.exception.ErrorCode;
 
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -16,5 +17,13 @@ public record ApiResponse<T> (
 
     public static ApiResponse<Void> success() {
         return new ApiResponse<>("5000", "SUCCESS","API 요청에 성공했습니다", null);
+    }
+
+    public static ApiResponse<Void> fail(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getCode(), "FAIL", errorCode.getMessage(), null);
+    }
+
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode, T data) {
+        return new ApiResponse<>(errorCode.getCode(), "ERROR", errorCode.getMessage(), data);
     }
 }

--- a/lodge/src/main/java/com/haot/lodge/common/response/ApiResponse.java
+++ b/lodge/src/main/java/com/haot/lodge/common/response/ApiResponse.java
@@ -20,7 +20,7 @@ public record ApiResponse<T> (
     }
 
     public static ApiResponse<Void> fail(ErrorCode errorCode) {
-        return new ApiResponse<>(errorCode.getCode(), "FAIL", errorCode.getMessage(), null);
+        return new ApiResponse<>(errorCode.getCode(), "ERROR", errorCode.getMessage(), null);
     }
 
     public static <T> ApiResponse<T> fail(ErrorCode errorCode, T data) {

--- a/lodge/src/main/java/com/haot/lodge/domain/model/Lodge.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/Lodge.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.domain.model;
 
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -52,12 +53,25 @@ public class Lodge {
     @JoinColumn(name = "lodge_rule_id")
     private LodgeRule rule;
 
-    @OneToMany(mappedBy = "lodge")
+    @OneToMany(mappedBy = "lodge", cascade = CascadeType.ALL)
     @Builder.Default
     private List<LodgeImage> images = new ArrayList<>();
 
-    @OneToMany(mappedBy = "lodge")
+    @OneToMany(mappedBy = "lodge", cascade = CascadeType.ALL)
     @Builder.Default
     private List<LodgeDate> dates = new ArrayList<>();
+
+    public static Lodge createLodge(
+            String hostId, String name, String description, String address, Integer term, Double basicPrice
+    ) {
+        return Lodge.builder()
+                .hostId(hostId)
+                .name(name)
+                .description(description)
+                .address(address)
+                .term(term)
+                .basicPrice(basicPrice)
+                .build();
+    }
 
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/model/Lodge.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/Lodge.java
@@ -53,11 +53,11 @@ public class Lodge {
     @JoinColumn(name = "lodge_rule_id")
     private LodgeRule rule;
 
-    @OneToMany(mappedBy = "lodge", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "lodge")
     @Builder.Default
     private List<LodgeImage> images = new ArrayList<>();
 
-    @OneToMany(mappedBy = "lodge", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "lodge")
     @Builder.Default
     private List<LodgeDate> dates = new ArrayList<>();
 

--- a/lodge/src/main/java/com/haot/lodge/domain/model/LodgeDate.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/LodgeDate.java
@@ -44,4 +44,14 @@ public class LodgeDate {
     @Enumerated(EnumType.STRING)
     private ReservationStatus status;
 
+    public static LodgeDate create(
+            Lodge lodge, LocalDate date, Double price, ReservationStatus status
+    ) {
+        return LodgeDate.builder()
+                .lodge(lodge)
+                .date(date)
+                .price(price)
+                .status(ReservationStatus.EMPTY)
+                .build();
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/model/LodgeImage.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/LodgeImage.java
@@ -41,4 +41,15 @@ public class LodgeImage {
     @Column(name = "url", nullable = false)
     private String url;
 
+    public static LodgeImage create(
+            Lodge lodge,  String url, String title, String description
+    ) {
+        return LodgeImage.builder()
+                .lodge(lodge)
+                .title(title)
+                .description(description)
+                .url(url)
+                .build();
+    }
+
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/model/LodgeRule.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/LodgeRule.java
@@ -40,4 +40,15 @@ public class LodgeRule {
     @Column(name = "customization")
     private String customization;
 
+
+    public static LodgeRule create(
+            Lodge lodge, Integer maxReservationDay, Integer maxPersonnel, String customization
+    ) {
+        return LodgeRule.builder()
+                .lodge(lodge)
+                .maxReservationDay(maxReservationDay)
+                .maxPersonnel(maxPersonnel)
+                .customization(customization)
+                .build();
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/model/enums/ReservationStatus.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/enums/ReservationStatus.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum ReservationStatus {
+    UNSELECTABLE("선택 불가능"),
     EMPTY("예약 없음"),
     WAITING("예약 대기"),
     COMPLETE("예약 완료");

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateRepository.java
@@ -1,0 +1,4 @@
+package com.haot.lodge.domain.repository;
+
+public interface LodgeDateRepository {
+}

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateRepository.java
@@ -1,4 +1,10 @@
 package com.haot.lodge.domain.repository;
 
-public interface LodgeDateRepository {
+
+import com.haot.lodge.domain.model.LodgeDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LodgeDateRepository extends JpaRepository<LodgeDate, String> {
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeImageRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeImageRepository.java
@@ -1,4 +1,10 @@
 package com.haot.lodge.domain.repository;
 
-public interface LodgeImageRepository {
+import com.haot.lodge.domain.model.LodgeImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+
+@ResponseStatus
+public interface LodgeImageRepository extends JpaRepository<LodgeImage, String> {
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeImageRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeImageRepository.java
@@ -1,0 +1,4 @@
+package com.haot.lodge.domain.repository;
+
+public interface LodgeImageRepository {
+}

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRepository.java
@@ -1,4 +1,12 @@
 package com.haot.lodge.domain.repository;
 
-public interface LodgeRepository {
+
+import com.haot.lodge.domain.model.Lodge;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus
+public interface LodgeRepository extends JpaRepository<Lodge, String> {
+    Optional<Lodge> findByHostIdAndName(String hostId, String name);
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRepository.java
@@ -1,0 +1,4 @@
+package com.haot.lodge.domain.repository;
+
+public interface LodgeRepository {
+}

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRuleRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRuleRepository.java
@@ -1,0 +1,4 @@
+package com.haot.lodge.domain.repository;
+
+public interface LodgeRuleRepository {
+}

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRuleRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRuleRepository.java
@@ -1,4 +1,10 @@
 package com.haot.lodge.domain.repository;
 
-public interface LodgeRuleRepository {
+
+import com.haot.lodge.domain.model.LodgeRule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LodgeRuleRepository extends JpaRepository<LodgeRule, String> {
 }

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
@@ -3,6 +3,7 @@ package com.haot.lodge.presentation.controller;
 
 import com.haot.lodge.application.response.LodgeResponse;
 import com.haot.lodge.application.response.lodgeImageResponse;
+import com.haot.lodge.application.service.LodgeService;
 import com.haot.lodge.presentation.response.LodgeReadAllResponse;
 import com.haot.lodge.application.response.LodgeRuleResponse;
 import com.haot.lodge.presentation.request.LodgeCreateRequest;
@@ -33,19 +34,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LodgeController {
 
+    private final LodgeService lodgeService;
+
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public ApiResponse<LodgeCreateResponse> create(
             @Valid LodgeCreateRequest request
     ) {
-        LodgeResponse info = LodgeResponse.builder()
-                .id("UUID")
-                .name("이름")
-                .description("휴양지입니다.")
-                .term(2)
-                .address("경기도 고양시 고양로 551")
-                .build();
-        return ApiResponse.success(new LodgeCreateResponse(info));
+        String userId = "UUID"; // 임시 유저 ID (Header 에서 가져오도록 수정 필요)
+        LodgeResponse lodge = lodgeService.createLodge(userId, request);
+        return ApiResponse.success(new LodgeCreateResponse(lodge));
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/lodge/src/main/java/com/haot/lodge/presentation/request/LodgeCreateRequest.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/request/LodgeCreateRequest.java
@@ -12,9 +12,9 @@ public record LodgeCreateRequest(
         @NotBlank String address,
         @NotNull Integer term,
         @NotNull Double basicPrice,
-        @NotNull List<MultipartFile> images,
-        @NotNull List<String> imageTitles,
-        @NotNull List<String> imageDescriptions,
+        @NotNull MultipartFile image,
+        @NotNull String imageTitle,
+        @NotNull String imageDescription,
         @NotNull Integer maxReservationDay,
         @NotNull Integer maxPersonnel,
         String customization,
@@ -22,4 +22,5 @@ public record LodgeCreateRequest(
         @NotNull LocalDate endDate,
         List<LocalDate> excludeDates
 ) {
+
 }

--- a/lodge/src/main/resources/validation-messages-ko.properties
+++ b/lodge/src/main/resources/validation-messages-ko.properties
@@ -1,0 +1,2 @@
+jakarta.validation.constraints.NotBlank.message=이 파라미터는 공백이 올 수 없습니다.
+jakarta.validation.constraints.NotNull.message=이 파라미터는 null 이 올 수 없습니다.


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #21 -> develop

처음 숙소를 생성하는 API 를 개발했습니다.
동시에 연결된 숙소 이미지, 숙소 룰, 숙소 날짜도 생성됩니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 각 모델(숙소, 숙소 이미지, 숙소 날짜, 숙소 규칙)에 생성 메서드 추가
- 각 모델별 서비스와 생성 메서드 추가
- 오류 상황에 맞는 에러 코드 추가, 에러 핸들러 추가

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공
![image](https://github.com/user-attachments/assets/037daa97-ef3a-4b72-b8eb-65f25ff984a9)

- 실패: 필요한 데이터 입력 안함
![image](https://github.com/user-attachments/assets/3dd5417f-14be-4979-8707-0c832043289f)

- 실패: 유저가 이미 생성한 이름의 숙소 있는 경우
![image](https://github.com/user-attachments/assets/c9716b00-169a-4fae-aaa8-0c816190ea34)

그 외 오류 상황 모두 체크했습니다.
- DB 에 각 테이블, 데이터 넣어진 것을 확인했습니다.
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- Valid 오류 메세지 설정은 성훈님 코드를 참고했습니다!
- 현재 S3가 없기 때문에 실제 Url 로 변환하는 코드는 이슈 작성해 추후 개발하겠습니다.
- 다른 예외도 추가할까 하다가 pr 안에 내용이 너무 많아질 것 같아서 생략했습니다. 추후 핸들러 따로 추가하겠습니다!
- 헤더에서 user id를 가져오는 부분은 넘어갔습니다. 추후 게이트웨이 설정되면 해당 부분 추가하겠습니다!
- 패키지 보시면 하나의 서비스가 여러 서비스 참조하고 그 각 서비스가 레포지토리를 참조하는 좀 복잡한 형태인데, 제 숙소 생성 기능이 한번 생성할 때 다른 엔티티도 생성해야 해서 이걸 각 모델 별 서비스에 create 메서드를 만들어 호출하려고 했는데 한 서비스 안에서 레포지토리도 갖고 다른 서비스도 갖는게 좋지 않을 것 같아서 멘토님께 질문드리니까 상위에서 모두 다루는 걸 만들던가 하는 방식을 제안해주셔서 일단 이렇게 했습니다 😥 패키지 고민에 시간을 많이 썼는데도 답이 잘 안나와서 일단 기능 만드는거 먼저 해야겠다는 생각이 들어서 이 상태로 PR 올립니다 추후 꼭 리팩터링 하도록 하겠습니다!! 혹시 이런 패키지 구조 관련해서 생각나시는 의견 있으시면 말씀해주시면 감사하겠습니다!!