### PR TITLE
[Feat] Lodge: 숙소 날짜 상태 변경 API

### DIFF
--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeDateService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeDateService.java
@@ -48,6 +48,16 @@ public class LodgeDateService {
         lodgeDateRepository.saveAll(lodgeDates);
     }
 
+    @Transactional
+    public void updateStatus(List<String> ids, String requestStatus) {
+        ReservationStatus status = ReservationStatus.fromString(requestStatus);
+        ids.forEach(id -> {
+            LodgeDate lodgeDate = lodgeDateRepository.findById(id)
+                    .orElseThrow(()-> new LodgeException(ErrorCode.LODGE_DATE_NOT_FOUND));
+            lodgeDate.updateStatus(status);
+        });
+    }
+
     /**
      * 입력된 날짜 유효성 검사
      * @param startDate 숙소 시작 날짜

--- a/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
@@ -14,10 +14,12 @@ public enum ErrorCode {
     ALREADY_EXIST_REVIEW(HttpStatus.CONFLICT, "5001","같은 이름의 숙소가 이미 존재합니다."),
 
     // 5100: LodgeDate Error
+    LODGE_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "5100", "일치하는 숙소 날짜를 찾을 수 없습니다."),
     START_DATE_IN_PAST(HttpStatus.BAD_REQUEST, "5101", "시작 날짜는 현재 날짜 이후여야 합니다."),
     START_DATE_AFTER_END_DATE(HttpStatus.BAD_REQUEST, "5102", "시작 날짜는 종료 날짜보다 이전이어야 합니다."),
     DATE_RANGE_TOO_SHORT(HttpStatus.BAD_REQUEST, "5103", "날짜 범위는 최소 30일 이상이어야 합니다."),
-    DATE_RANGE_TOO_LONG(HttpStatus.BAD_REQUEST, "5104", "날짜 범위는 최대 365일을 초과할 수 없습니다.");
+    DATE_RANGE_TOO_LONG(HttpStatus.BAD_REQUEST, "5104", "날짜 범위는 최대 365일을 초과할 수 없습니다."),
+    INVALID_DATE_STATUS(HttpStatus.BAD_REQUEST, "5105", "상태 타입이 유효하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/lodge/src/main/java/com/haot/lodge/domain/model/LodgeDate.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/LodgeDate.java
@@ -44,6 +44,10 @@ public class LodgeDate {
     @Enumerated(EnumType.STRING)
     private ReservationStatus status;
 
+    public void updateStatus(ReservationStatus status) {
+        this.status = status;
+    }
+
     public static LodgeDate create(
             Lodge lodge, LocalDate date, Double price, ReservationStatus status
     ) {

--- a/lodge/src/main/java/com/haot/lodge/domain/model/enums/ReservationStatus.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/enums/ReservationStatus.java
@@ -1,5 +1,7 @@
 package com.haot.lodge.domain.model.enums;
 
+import com.haot.lodge.common.exception.ErrorCode;
+import com.haot.lodge.common.exception.LodgeException;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
@@ -10,4 +12,15 @@ public enum ReservationStatus {
     COMPLETE("예약 완료");
 
     private final String description;
+
+    public static ReservationStatus fromString(String request){
+        request = request.toUpperCase();
+        return switch (request){
+            case "UNSELECTABLE" -> UNSELECTABLE;
+            case "EMPTY" -> EMPTY;
+            case "WAITING" -> WAITING;
+            case "COMPLETE" -> COMPLETE;
+            default -> throw new LodgeException(ErrorCode.INVALID_DATE_STATUS);
+        };
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeDateController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeDateController.java
@@ -2,10 +2,13 @@ package com.haot.lodge.presentation.controller;
 
 
 import com.haot.lodge.application.response.LodgeDateResponse;
+import com.haot.lodge.application.service.Impl.LodgeDateService;
 import com.haot.lodge.common.response.ApiResponse;
 import com.haot.lodge.domain.model.enums.ReservationStatus;
 import com.haot.lodge.presentation.request.LodgeDateUpdateRequest;
+import com.haot.lodge.presentation.request.LodgeDateUpdateStatusRequest;
 import com.haot.lodge.presentation.response.LodgeDateReadResponse;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +31,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/lodge-dates")
 @RequiredArgsConstructor
 public class LodgeDateController {
+
+    private final LodgeDateService lodgeDateService;
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
@@ -65,20 +70,13 @@ public class LodgeDateController {
         return ApiResponse.success();
     }
 
-    /**
-     * 예약 날짜 상태 변경 API
-     * @param dateId 변경할 날짜 id
-     * @param status 변경할 상태 (EMPTY/WAITING/COMPLETE)
-     * @return 기본 성공 응답
-     */
+    @PostMapping("/status")
     @ResponseStatus(HttpStatus.OK)
-    @PostMapping("/{dateId}")
     public ApiResponse<Void> updateStatus(
-            @PathVariable(name = "dateId") String dateId,
-            @RequestParam(name = "status", required = true) ReservationStatus status
+            @Valid @RequestBody LodgeDateUpdateStatusRequest request
     ) {
+        lodgeDateService.updateStatus(request.lodgeDateIds(), request.status());
         return ApiResponse.success();
     }
-
 
 }

--- a/lodge/src/main/java/com/haot/lodge/presentation/request/LodgeDateUpdateStatusRequest.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/request/LodgeDateUpdateStatusRequest.java
@@ -1,0 +1,10 @@
+package com.haot.lodge.presentation.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record LodgeDateUpdateStatusRequest(
+        @NotNull List<String> lodgeDateIds,
+        @NotNull String status
+) {
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #44 

숙소 날짜의 상태를 변경하는 API 를 개발했습니다.
기본 오류 외 다음 상황에서 오류가 발생합니다. 
- id와 일치하는 숙소 날짜 정보가 없는 경우
- 요청으로 받은 status 가 유효하지 않을 경우
 
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 기존 path 를 통해 단 건을 수정하는 방식에서 List로 여러 건을 받아 수정하도록 변경
  - 변경 전 경로: api/v1/lodge-dates/{dateId}?status=
  - 변경 후 경로: api/v1/lodge-dates/status
- 상태 Enum 에 String->Enum 메서드 추가
- 엔티티에 상태만 없데이트 할 수 있도록 메서드 추가
- 변경 요청 객체 추가


## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공
![image](https://github.com/user-attachments/assets/8cb9b3c1-8246-491d-aa56-c0d2aeba5cda)

- 오류: 유효하지 않은 상태를 요청으로 보낸 경우
![image](https://github.com/user-attachments/assets/83108982-f133-4462-be6e-d3cec73257d0)

- DB 에 반영 확인했습니다!
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!