### PR TITLE
[Feat] Lodge: 숙소 단건 조회 API

### DIFF
--- a/lodge/src/main/java/com/haot/lodge/application/response/LodgeRuleResponse.java
+++ b/lodge/src/main/java/com/haot/lodge/application/response/LodgeRuleResponse.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.application.response;
 
 
+import com.haot.lodge.domain.model.LodgeRule;
 import lombok.Builder;
 
 @Builder
@@ -10,4 +11,12 @@ public record LodgeRuleResponse(
         Integer maxPersonnel,
         String customization
 ) {
+    public static LodgeRuleResponse from(LodgeRule rule) {
+        return new LodgeRuleResponse(
+                rule.getId(),
+                rule.getMaxReservationDay(),
+                rule.getMaxPersonnel(),
+                rule.getCustomization()
+        );
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/application/response/lodgeImageResponse.java
+++ b/lodge/src/main/java/com/haot/lodge/application/response/lodgeImageResponse.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.application.response;
 
 
+import com.haot.lodge.domain.model.LodgeImage;
 import lombok.Builder;
 
 @Builder
@@ -10,4 +11,12 @@ public record LodgeImageResponse(
         String description,
         String url
 ){
+    public static LodgeImageResponse from(LodgeImage lodgeImage) {
+        return new LodgeImageResponse(
+                lodgeImage.getId(),
+                lodgeImage.getTitle(),
+                lodgeImage.getDescription(),
+                lodgeImage.getUrl()
+        );
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/application/response/lodgeImageResponse.java
+++ b/lodge/src/main/java/com/haot/lodge/application/response/lodgeImageResponse.java
@@ -4,7 +4,7 @@ package com.haot.lodge.application.response;
 import lombok.Builder;
 
 @Builder
-public record lodgeImageResponse(
+public record LodgeImageResponse(
         String id,
         String title,
         String description,

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeBasicService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeBasicService.java
@@ -7,7 +7,6 @@ import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.repository.LodgeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,10 +23,17 @@ public class LodgeBasicService {
             Double basicPrice
     ) {
         if(lodgeRepository.findByHostIdAndName(userId, name).isPresent()) {
-            throw new LodgeException(ErrorCode.ALREADY_EXIST_REVIEW);
+            throw new LodgeException(ErrorCode.ALREADY_EXIST_LODGE_NAME);
         }
         return lodgeRepository.save(Lodge.createLodge(
                 userId, name, description, address, term, basicPrice
         ));
     }
+
+    public Lodge getLodgeById(String lodgeId) {
+        return lodgeRepository.findById(lodgeId)
+                .orElseThrow(()->new LodgeException(ErrorCode.LODGE_NOT_FOUND));
+        // TODO: isDeleted = true 인 경우 제외되도록 해야 함
+    }
+
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeRuleService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeRuleService.java
@@ -1,6 +1,8 @@
 package com.haot.lodge.application.service.Impl;
 
 
+import com.haot.lodge.common.exception.ErrorCode;
+import com.haot.lodge.common.exception.LodgeException;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.model.LodgeRule;
 import com.haot.lodge.domain.repository.LodgeRuleRepository;
@@ -21,5 +23,10 @@ public class LodgeRuleService {
         lodgeRuleRepository.save(
                 LodgeRule.create(linkedLodge, maxReservationDay, maxPersonnel, customization)
         );
+    }
+
+    public LodgeRule getLodgeRuleByLodgeId(String lodgeId) {
+        return lodgeRuleRepository.findLodgeRuleByLodgeId(lodgeId)
+                .orElseThrow(()->new LodgeException(ErrorCode.LODGE_RULE_NOT_FOUND));
     }
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
@@ -1,17 +1,22 @@
 package com.haot.lodge.application.service;
 
 
+import com.haot.lodge.application.response.LodgeImageResponse;
 import com.haot.lodge.application.response.LodgeResponse;
+import com.haot.lodge.application.response.LodgeRuleResponse;
 import com.haot.lodge.application.service.Impl.LodgeDateService;
 import com.haot.lodge.application.service.Impl.LodgeImageService;
 import com.haot.lodge.application.service.Impl.LodgeRuleService;
 import com.haot.lodge.application.service.Impl.LodgeBasicService;
 import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeRule;
 import com.haot.lodge.presentation.request.LodgeCreateRequest;
+import com.haot.lodge.presentation.response.LodgeReadOneResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@org.springframework.stereotype.Service
+@Service
 @RequiredArgsConstructor
 @Transactional
 public class LodgeService {
@@ -31,6 +36,20 @@ public class LodgeService {
         lodgeRuleService.create(lodge, request.maxReservationDay(), request.maxPersonnel(), request.customization());
         lodgeDateService.create(lodge, request.startDate(), request.endDate(), request.excludeDates());
         return LodgeResponse.from(lodge);
+    }
+
+    @Transactional(readOnly = true)
+    public LodgeReadOneResponse readLodge(String lodgeId) {
+        Lodge lodge = lodgeBasicService.getLodgeById(lodgeId);
+        LodgeRule rule = lodgeRuleService.getLodgeRuleByLodgeId(lodgeId);
+        return new LodgeReadOneResponse(
+                LodgeResponse.from(lodge),
+                lodge.getImages()
+                        .stream()
+                        .map(LodgeImageResponse::from)
+                        .toList(),
+                LodgeRuleResponse.from(rule)
+        );
     }
 
 }

--- a/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
@@ -11,7 +11,9 @@ public enum ErrorCode {
     VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "0009", "Validation failed"),
 
     // 5000: Lodge Error
-    ALREADY_EXIST_REVIEW(HttpStatus.CONFLICT, "5001","같은 이름의 숙소가 이미 존재합니다."),
+    LODGE_NOT_FOUND(HttpStatus.NOT_FOUND, "5001", "일치하는 숙소 정보를 찾을 수 없습니다."),
+    LODGE_RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "5002", "일치하는 숙소 규칙 정보를 찾을 수 없습니다."),
+    ALREADY_EXIST_LODGE_NAME(HttpStatus.CONFLICT, "5003","같은 이름의 숙소가 이미 존재합니다."),
 
     // 5100: LodgeDate Error
     START_DATE_IN_PAST(HttpStatus.BAD_REQUEST, "5101", "시작 날짜는 현재 날짜 이후여야 합니다."),

--- a/lodge/src/main/java/com/haot/lodge/domain/model/Lodge.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/Lodge.java
@@ -49,10 +49,6 @@ public class Lodge {
     @Column(name = "basic_price", nullable = false)
     private Double basicPrice;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "lodge_rule_id")
-    private LodgeRule rule;
-
     @OneToMany(mappedBy = "lodge")
     @Builder.Default
     private List<LodgeImage> images = new ArrayList<>();

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRuleRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeRuleRepository.java
@@ -2,9 +2,11 @@ package com.haot.lodge.domain.repository;
 
 
 import com.haot.lodge.domain.model.LodgeRule;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LodgeRuleRepository extends JpaRepository<LodgeRule, String> {
+    Optional<LodgeRule> findLodgeRuleByLodgeId(String lodgeId);
 }

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
@@ -2,7 +2,7 @@ package com.haot.lodge.presentation.controller;
 
 
 import com.haot.lodge.application.response.LodgeResponse;
-import com.haot.lodge.application.response.lodgeImageResponse;
+import com.haot.lodge.application.response.LodgeImageResponse;
 import com.haot.lodge.application.service.LodgeService;
 import com.haot.lodge.presentation.response.LodgeReadAllResponse;
 import com.haot.lodge.application.response.LodgeRuleResponse;
@@ -66,7 +66,7 @@ public class LodgeController {
                 .term(2)
                 .address("경기도 고양시 고양로 551")
                 .build();
-        lodgeImageResponse image = lodgeImageResponse.builder()
+        LodgeImageResponse image = LodgeImageResponse.builder()
                 .id("imageId")
                 .url("http://s3url")
                 .build();

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
@@ -88,29 +88,7 @@ public class LodgeController {
     public ApiResponse<LodgeReadOneResponse> readOne(
             @PathVariable String lodgeId
     ) {
-        LodgeResponse info = LodgeResponse.builder()
-                .id(lodgeId)
-                .name("이름")
-                .description("휴양지입니다.")
-                .term(2)
-                .address("경기도 고양시 고양로 551")
-                .build();
-        lodgeImageResponse image = lodgeImageResponse.builder()
-                .id("imageId")
-                .url("http://s3url")
-                .build();
-        LodgeRuleResponse rule = LodgeRuleResponse.builder()
-                .id("ruleId")
-                .maxPersonnel(12)
-                .maxReservationDay(5)
-                .customization("뛰지 말아주세요")
-                .build();
-        LodgeReadOneResponse response = LodgeReadOneResponse.builder()
-                .lodge(info)
-                .images(List.of(image))
-                .rule(rule)
-                .build();
-        return ApiResponse.success(response);
+        return ApiResponse.success(lodgeService.readLodge(lodgeId));
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/lodge/src/main/java/com/haot/lodge/presentation/response/LodgeReadAllResponse.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/response/LodgeReadAllResponse.java
@@ -1,13 +1,13 @@
 package com.haot.lodge.presentation.response;
 
 import com.haot.lodge.application.response.LodgeResponse;
-import com.haot.lodge.application.response.lodgeImageResponse;
+import com.haot.lodge.application.response.LodgeImageResponse;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record LodgeReadAllResponse(
         LodgeResponse lodge,
-        List<lodgeImageResponse> images
+        List<LodgeImageResponse> images
 ) {
 }

--- a/lodge/src/main/java/com/haot/lodge/presentation/response/LodgeReadOneResponse.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/response/LodgeReadOneResponse.java
@@ -1,7 +1,7 @@
 package com.haot.lodge.presentation.response;
 
 import com.haot.lodge.application.response.LodgeResponse;
-import com.haot.lodge.application.response.lodgeImageResponse;
+import com.haot.lodge.application.response.LodgeImageResponse;
 import com.haot.lodge.application.response.LodgeRuleResponse;
 import java.util.List;
 import lombok.Builder;
@@ -10,7 +10,7 @@ import lombok.Builder;
 @Builder
 public record LodgeReadOneResponse(
         LodgeResponse lodge,
-        List<lodgeImageResponse> images,
+        List<LodgeImageResponse> images,
         LodgeRuleResponse rule
 ) {
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #47 

숙소 id와 일치하는 숙소를 조회하는 API 를 개발했습니다.
일치하는 숙소가 없는 경우 오류를 반환합니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 숙소 이미지 응답 객체명 수정: lodgeImageResponse -> LodgeImageResponse
- 숙소 엔티티에서 숙소 룰 엔티티와의 1:1 연관관계 제거
- 일치하는 숙소, 숙소 룰 없는 경우의 오류 코드 추가

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- **성공**
![image](https://github.com/user-attachments/assets/b049f2c1-ac3b-4213-854e-a6217739864e)
해당 응답 명세서에 추가했습니다.

- **실패**: id와 일치하는 숙소 없는 경우
![image](https://github.com/user-attachments/assets/0d613c34-30d8-4952-92dc-dc6751872eca)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 숙소에서 숙소룰 연관관계는 원래 숙소만 조회해서 룰까지 가져오려고 한거였는데 룰쪽에도 연관관계가 매핑되어 있어서 생성 할 때 숙소 -> 숙소룰(숙소 전달) 방식으로 구현했더니 숙소쪽에 룰이 저장이 안되길래 그냥 제거하고 숙소룰 서비스에서 찾도록 했습니다. 혹시라도 더 좋은 의견 있으시면 말씀해주세요!
- isDeleted 제외는 BaseEntity 구현 이후 추가하도록 ToDo 로 작성했습니다.
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!