### PR TITLE
[Feat] Lodge: 숙소 날짜 목록 조회 API

### DIFF
--- a/lodge/build.gradle
+++ b/lodge/build.gradle
@@ -38,6 +38,13 @@ dependencies {
 
 	runtimeOnly 'org.postgresql:postgresql'
 
+	// querydsl
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'org.jetbrains:annotations:24.1.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/lodge/src/main/java/com/haot/lodge/application/response/LodgeDateResponse.java
+++ b/lodge/src/main/java/com/haot/lodge/application/response/LodgeDateResponse.java
@@ -1,15 +1,21 @@
 package com.haot.lodge.application.response;
 
+import com.haot.lodge.domain.model.LodgeDate;
 import com.haot.lodge.domain.model.enums.ReservationStatus;
 import java.time.LocalDate;
-import lombok.Builder;
 
-
-@Builder
 public record LodgeDateResponse(
         String id,
         LocalDate date,
         Double price,
         ReservationStatus status
-) {
+){
+    public static LodgeDateResponse from(LodgeDate lodgeDate) {
+        return new LodgeDateResponse(
+                lodgeDate.getId(),
+                lodgeDate.getDate(),
+                lodgeDate.getPrice(),
+                lodgeDate.getStatus()
+        );
+    }
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeDateService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/Impl/LodgeDateService.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.application.service.Impl;
 
 
+import com.haot.lodge.application.response.LodgeDateResponse;
 import com.haot.lodge.common.exception.ErrorCode;
 import com.haot.lodge.common.exception.LodgeException;
 import com.haot.lodge.domain.model.Lodge;
@@ -15,6 +16,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +49,14 @@ public class LodgeDateService {
             currentDate = currentDate.plusDays(1);
         }
         lodgeDateRepository.saveAll(lodgeDates);
+    }
+
+    public Slice<LodgeDateResponse> readAll(
+            Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
+    ) {
+        return lodgeDateRepository
+                .findAllLodgeDateByRange(pageable, lodge, start, end)
+                .map(LodgeDateResponse::from);
     }
 
     @Transactional

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.application.service;
 
 
+import com.haot.lodge.application.response.LodgeDateResponse;
 import com.haot.lodge.application.response.LodgeImageResponse;
 import com.haot.lodge.application.response.LodgeResponse;
 import com.haot.lodge.application.response.LodgeRuleResponse;
@@ -11,8 +12,12 @@ import com.haot.lodge.application.service.Impl.LodgeBasicService;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.model.LodgeRule;
 import com.haot.lodge.presentation.request.LodgeCreateRequest;
+import com.haot.lodge.presentation.response.LodgeDateReadResponse;
 import com.haot.lodge.presentation.response.LodgeReadOneResponse;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,6 +55,16 @@ public class LodgeService {
                         .toList(),
                 LodgeRuleResponse.from(rule)
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<LodgeDateReadResponse> readLodgeDates(
+            Pageable pageable, String lodgeId, LocalDate start, LocalDate end
+    ) {
+        Lodge lodge = lodgeBasicService.getLodgeById(lodgeId);
+        return lodgeDateService
+                .readAll(pageable, lodge, start, end)
+                .map(LodgeDateReadResponse::new);
     }
 
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
@@ -1,7 +1,6 @@
 package com.haot.lodge.application.service;
 
 
-import com.haot.lodge.application.response.LodgeDateResponse;
 import com.haot.lodge.application.response.LodgeImageResponse;
 import com.haot.lodge.application.response.LodgeResponse;
 import com.haot.lodge.application.response.LodgeRuleResponse;

--- a/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
@@ -21,7 +21,10 @@ public enum ErrorCode {
     START_DATE_AFTER_END_DATE(HttpStatus.BAD_REQUEST, "5102", "시작 날짜는 종료 날짜보다 이전이어야 합니다."),
     DATE_RANGE_TOO_SHORT(HttpStatus.BAD_REQUEST, "5103", "날짜 범위는 최소 30일 이상이어야 합니다."),
     DATE_RANGE_TOO_LONG(HttpStatus.BAD_REQUEST, "5104", "날짜 범위는 최대 365일을 초과할 수 없습니다."),
-    INVALID_DATE_STATUS(HttpStatus.BAD_REQUEST, "5105", "상태 타입이 유효하지 않습니다.");
+    INVALID_DATE_STATUS(HttpStatus.BAD_REQUEST, "5105", "상태 타입이 유효하지 않습니다."),
+
+    // 5500: Service Common
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "5500", "지원하지 않는 정렬 방식입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/lodge/src/main/java/com/haot/lodge/domain/config/QueryDslConfig.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.haot.lodge.domain.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jPAQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateCustomRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateCustomRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.domain.Slice;
 
 public interface LodgeDateCustomRepository {
     Slice<LodgeDate> findAllLodgeDateByRange(
-            Pageable pageable,Lodge lodge, LocalDate start, LocalDate end
+            Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
     );
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateCustomRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateCustomRepository.java
@@ -1,0 +1,13 @@
+package com.haot.lodge.domain.repository;
+
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeDate;
+import java.time.LocalDate;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface LodgeDateCustomRepository {
+    Slice<LodgeDate> findAllLodgeDateByRange(
+            Pageable pageable,Lodge lodge, LocalDate start, LocalDate end
+    );
+}

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LodgeDateRepository extends JpaRepository<LodgeDate, String> {
+public interface LodgeDateRepository extends JpaRepository<LodgeDate, String>, LodgeDateCustomRepository {
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/impl/LodgeDateCustomRepositoryImpl.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/impl/LodgeDateCustomRepositoryImpl.java
@@ -1,0 +1,90 @@
+package com.haot.lodge.domain.repository.impl;
+
+import static com.haot.lodge.domain.model.QLodgeDate.lodgeDate;
+
+import com.haot.lodge.common.exception.ErrorCode;
+import com.haot.lodge.common.exception.LodgeException;
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeDate;
+import com.haot.lodge.domain.repository.LodgeDateCustomRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LodgeDateCustomRepositoryImpl implements LodgeDateCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<LodgeDate> findAllLodgeDateByRange(
+            Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
+    ) {
+        BooleanBuilder booleanBuilder = getBooleanBuilder(lodge, start, end);
+        List<LodgeDate> result = queryFactory.selectFrom(lodgeDate)
+                .where(booleanBuilder)
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Long> count = queryFactory.select(lodgeDate.count())
+                .from(lodgeDate)
+                .where(booleanBuilder);
+        return PageableExecutionUtils.getPage(result, pageable, count::fetchOne);
+    }
+
+    private BooleanBuilder getBooleanBuilder(
+            Lodge lodge, LocalDate start, LocalDate end
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(eqLodge(lodge));
+        builder.and(afterStart(start));
+        builder.and(beforeEnd(end));
+        builder.and(lodgeDate.isDeleted.eq(false));
+        return builder;
+    }
+
+    private BooleanExpression eqLodge(Lodge linkedLodge) {
+        return lodgeDate.lodge.eq(linkedLodge);
+    }
+
+    private BooleanExpression afterStart(LocalDate start) {
+        return (start==null) ? null : lodgeDate.date.after(start.minusDays(1));
+    }
+
+    private BooleanExpression beforeEnd(LocalDate end) {
+        return (end==null) ? null : lodgeDate.date.before(end.plusDays(1));
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    ComparableExpressionBase<?> sortPath = getSortPath(order.getProperty());
+                    return new OrderSpecifier<>(
+                            order.isAscending()
+                                    ? com.querydsl.core.types.Order.ASC
+                                    : com.querydsl.core.types.Order.DESC,
+                            sortPath);
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    private ComparableExpressionBase<?> getSortPath(String property) {
+        return switch (property) {
+            case "date" -> lodgeDate.date;
+            case "createdAt" -> lodgeDate.createdAt;
+            case "updatedAt" -> lodgeDate.updatedAt;
+            default -> throw new LodgeException(ErrorCode.UNSUPPORTED_SORT_TYPE);
+        };
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeDateController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeDateController.java
@@ -1,21 +1,20 @@
 package com.haot.lodge.presentation.controller;
 
 
-import com.haot.lodge.application.response.LodgeDateResponse;
 import com.haot.lodge.application.service.Impl.LodgeDateService;
+import com.haot.lodge.application.service.LodgeService;
 import com.haot.lodge.common.response.ApiResponse;
-import com.haot.lodge.domain.model.enums.ReservationStatus;
 import com.haot.lodge.presentation.request.LodgeDateUpdateRequest;
 import com.haot.lodge.presentation.request.LodgeDateUpdateStatusRequest;
 import com.haot.lodge.presentation.response.LodgeDateReadResponse;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,33 +31,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LodgeDateController {
 
+    private final LodgeService lodgeService;
     private final LodgeDateService lodgeDateService;
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
     public ApiResponse<Slice<LodgeDateReadResponse>> read(
             @PageableDefault(size = 30)
+            @SortDefault(sort = "date", direction = Direction.ASC)
             Pageable pageable,
             @RequestParam(name = "lodgeId", required = true) String lodgeId,
             @RequestParam(name = "start", required = false) LocalDate start,
             @RequestParam(name = "end", required = false) LocalDate end
     ) {
-        LodgeDateResponse dto = LodgeDateResponse.builder()
-                .id("UUID")
-                .date(start)
-                .price(120000.0)
-                .status(ReservationStatus.EMPTY)
-                .build();
-        LodgeDateResponse dto2 = LodgeDateResponse.builder()
-                .id("UUID2")
-                .date(end)
-                .price(120000.0)
-                .status(ReservationStatus.EMPTY)
-                .build();
-        List<LodgeDateReadResponse> dates =
-                List.of(new LodgeDateReadResponse(dto), new LodgeDateReadResponse(dto2));
-        Slice<LodgeDateReadResponse> response = new SliceImpl<>(dates, pageable, false);
-        return ApiResponse.success(response);
+        return ApiResponse.success(
+                lodgeService.readLodgeDates(pageable, lodgeId, start, end)
+        );
     }
 
     @ResponseStatus(HttpStatus.OK)


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #52 

숙소 날짜 목록을 조회하는 API를 개발했습니다.

주요 파라미터
- **sort**: 정렬 기준, 기본 값 -> date,DESC
- **size**: 조회할 목록 크기, 기본 값 -> 30
- **lodgeId**: 필수, 확인할 숙소
- **start**: 선택, 지정한 날짜부터 시작
- **end**: 선택, 지정한 날짜까지 조회
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 쿼리 DSL 의존성, 설정 추가
- 지원하지 않는 정렬방식인 경우의 오류 코드 추가
- 커스텀 레포지토리 생성 및 조회 메서드 구현

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
조회 성공 (기본/날짜 오름차순)
- /api/v1/lodge-dates?lodgeId={id}&start=2025-01-07&end=2025-01-30
![image](https://github.com/user-attachments/assets/36a5cdf0-310e-4197-b840-2c6034c9e89f)

조회 성공 (날짜 내림차순)
- /api/v1/lodge-dates?lodgeId={id}&start=2025-01-07&end=2025-01-30&sort=date,DESC
![image](https://github.com/user-attachments/assets/41e3d0d9-5532-4ed8-9860-5784a3f00489)

기본 조회 성공 응답은 API 명세서의 응답 예시에 작성해놨습니다.
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!