### PR TITLE
[Refactor] Lodge: 서비스 Facade 패턴 적용

### DIFF
--- a/lodge/src/main/java/com/haot/lodge/application/facade/LodgeDateFacade.java
+++ b/lodge/src/main/java/com/haot/lodge/application/facade/LodgeDateFacade.java
@@ -1,0 +1,44 @@
+package com.haot.lodge.application.facade;
+
+
+import com.haot.lodge.application.service.LodgeDateService;
+import com.haot.lodge.application.service.LodgeService;
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeDate;
+import com.haot.lodge.domain.model.enums.ReservationStatus;
+import com.haot.lodge.presentation.response.LodgeDateReadResponse;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LodgeDateFacade {
+
+    private final LodgeService lodgeService;
+    private final LodgeDateService lodgeDateService;
+
+    @Transactional(readOnly = true)
+    public Slice<LodgeDateReadResponse> readLodgeDates(
+            Pageable pageable, String lodgeId, LocalDate start, LocalDate end
+    ) {
+        Lodge lodge = lodgeService.getValidLodgeById(lodgeId);
+        return lodgeDateService
+                .readAll(pageable, lodge, start, end)
+                .map(LodgeDateReadResponse::new);
+    }
+
+    @Transactional
+    public void updateStatus(List<String> ids, String requestStatus) {
+        ReservationStatus status = ReservationStatus.fromString(requestStatus);
+        ids.forEach(id -> {
+            LodgeDate lodgeDate = lodgeDateService.getValidLodgeDateById(id);
+            lodgeDateService.updateStatus(lodgeDate, status);
+        });
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/application/facade/LodgeFacade.java
+++ b/lodge/src/main/java/com/haot/lodge/application/facade/LodgeFacade.java
@@ -1,0 +1,57 @@
+package com.haot.lodge.application.facade;
+
+
+import com.haot.lodge.application.response.LodgeImageResponse;
+import com.haot.lodge.application.response.LodgeResponse;
+import com.haot.lodge.application.response.LodgeRuleResponse;
+import com.haot.lodge.application.service.LodgeDateService;
+import com.haot.lodge.application.service.LodgeImageService;
+import com.haot.lodge.application.service.LodgeRuleService;
+import com.haot.lodge.application.service.LodgeService;
+import com.haot.lodge.application.service.implement.LodgeServiceImpl;
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeRule;
+import com.haot.lodge.presentation.request.LodgeCreateRequest;
+import com.haot.lodge.presentation.response.LodgeReadOneResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LodgeFacade {
+
+    private final LodgeService lodgeService;
+    private final LodgeImageService lodgeImageService;
+    private final LodgeRuleService lodgeRuleService;
+    private final LodgeDateService lodgeDateService;
+
+    @Transactional
+    public LodgeResponse createLodge(String userId, LodgeCreateRequest request) {
+        // TODO: UserId 유효성 검증
+        Lodge lodge = lodgeService.create(
+                userId, request.name(), request.description(),
+                request.address(), request.term(), request.basicPrice());
+        lodgeImageService.create(lodge, request.image(), request.imageTitle(), request.imageDescription());
+        lodgeRuleService.create(lodge, request.maxReservationDay(), request.maxPersonnel(), request.customization());
+        lodgeDateService.create(lodge, request.startDate(), request.endDate(), request.excludeDates());
+        return LodgeResponse.from(lodge);
+    }
+
+    @Transactional(readOnly = true)
+    public LodgeReadOneResponse readLodge(String lodgeId) {
+        Lodge lodge = lodgeService.getValidLodgeById(lodgeId);
+        LodgeRule rule = lodgeRuleService.getLodgeRuleByLodgeId(lodgeId);
+        return new LodgeReadOneResponse(
+                LodgeResponse.from(lodge),
+                lodge.getImages()
+                        .stream()
+                        .map(LodgeImageResponse::from)
+                        .toList(),
+                LodgeRuleResponse.from(rule)
+        );
+    }
+
+
+}

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeDateService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeDateService.java
@@ -1,0 +1,29 @@
+package com.haot.lodge.application.service;
+
+import com.haot.lodge.application.response.LodgeDateResponse;
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeDate;
+import com.haot.lodge.domain.model.enums.ReservationStatus;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface LodgeDateService {
+
+    LodgeDate getValidLodgeDateById(String lodgeDateId);
+
+    void create(
+            Lodge lodge,
+            LocalDate startDate,
+            LocalDate endDate,
+            List<LocalDate> excludeDates
+    );
+
+    Slice<LodgeDateResponse> readAll(
+            Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
+    );
+
+
+    void updateStatus(LodgeDate lodgeDate, ReservationStatus requestStatus);
+}

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeImageService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeImageService.java
@@ -1,0 +1,14 @@
+package com.haot.lodge.application.service;
+
+import com.haot.lodge.domain.model.Lodge;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface LodgeImageService {
+
+    void create(
+            Lodge lodge,
+            MultipartFile file,
+            String title,
+            String description
+    );
+}

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeRuleService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeRuleService.java
@@ -1,0 +1,16 @@
+package com.haot.lodge.application.service;
+
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.domain.model.LodgeRule;
+
+public interface LodgeRuleService {
+
+    LodgeRule getLodgeRuleByLodgeId(String lodgeId);
+
+    void create(
+            Lodge linkedLodge,
+            Integer maxReservationDay,
+            Integer maxPersonnel,
+            String customization
+    );
+}

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
@@ -1,69 +1,19 @@
 package com.haot.lodge.application.service;
 
-
-import com.haot.lodge.application.response.LodgeImageResponse;
-import com.haot.lodge.application.response.LodgeResponse;
-import com.haot.lodge.application.response.LodgeRuleResponse;
-import com.haot.lodge.application.service.Impl.LodgeDateService;
-import com.haot.lodge.application.service.Impl.LodgeImageService;
-import com.haot.lodge.application.service.Impl.LodgeRuleService;
-import com.haot.lodge.application.service.Impl.LodgeBasicService;
 import com.haot.lodge.domain.model.Lodge;
-import com.haot.lodge.domain.model.LodgeRule;
-import com.haot.lodge.presentation.request.LodgeCreateRequest;
-import com.haot.lodge.presentation.response.LodgeDateReadResponse;
-import com.haot.lodge.presentation.response.LodgeReadOneResponse;
-import java.time.LocalDate;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-@Transactional
-public class LodgeService {
 
-    private final LodgeBasicService lodgeBasicService;
-    private final LodgeImageService lodgeImageService;
-    private final LodgeRuleService lodgeRuleService;
-    private final LodgeDateService lodgeDateService;
+public interface LodgeService {
 
-    @Transactional
-    public LodgeResponse createLodge(String userId, LodgeCreateRequest request) {
-        // TODO: UserId 유효성 검증
-        Lodge lodge = lodgeBasicService.create(
-                userId, request.name(), request.description(), request.address(),
-                request.term(), request.basicPrice());
-        lodgeImageService.create(lodge, request.image(), request.imageTitle(), request.imageDescription());
-        lodgeRuleService.create(lodge, request.maxReservationDay(), request.maxPersonnel(), request.customization());
-        lodgeDateService.create(lodge, request.startDate(), request.endDate(), request.excludeDates());
-        return LodgeResponse.from(lodge);
-    }
+    Lodge getValidLodgeById(String lodgeId);
 
-    @Transactional(readOnly = true)
-    public LodgeReadOneResponse readLodge(String lodgeId) {
-        Lodge lodge = lodgeBasicService.getLodgeById(lodgeId);
-        LodgeRule rule = lodgeRuleService.getLodgeRuleByLodgeId(lodgeId);
-        return new LodgeReadOneResponse(
-                LodgeResponse.from(lodge),
-                lodge.getImages()
-                        .stream()
-                        .map(LodgeImageResponse::from)
-                        .toList(),
-                LodgeRuleResponse.from(rule)
-        );
-    }
-
-    @Transactional(readOnly = true)
-    public Slice<LodgeDateReadResponse> readLodgeDates(
-            Pageable pageable, String lodgeId, LocalDate start, LocalDate end
-    ) {
-        Lodge lodge = lodgeBasicService.getLodgeById(lodgeId);
-        return lodgeDateService
-                .readAll(pageable, lodge, start, end)
-                .map(LodgeDateReadResponse::new);
-    }
+    Lodge create(
+            String userId,
+            String name,
+            String description,
+            String address,
+            Integer term,
+            Double basicPrice
+    );
 
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeDateServiceImpl.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeDateServiceImpl.java
@@ -1,7 +1,8 @@
-package com.haot.lodge.application.service.Impl;
+package com.haot.lodge.application.service.implement;
 
 
 import com.haot.lodge.application.response.LodgeDateResponse;
+import com.haot.lodge.application.service.LodgeDateService;
 import com.haot.lodge.common.exception.ErrorCode;
 import com.haot.lodge.common.exception.LodgeException;
 import com.haot.lodge.domain.model.Lodge;
@@ -19,18 +20,23 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class LodgeDateService {
+public class LodgeDateServiceImpl implements LodgeDateService {
 
     private final LodgeDateRepository lodgeDateRepository;
     private final Integer MIN_RANGE = 30;
     private final Integer MAX_RANGE = 365;
 
 
-    @Transactional
+    @Override
+    public LodgeDate getValidLodgeDateById(String lodgeDateId) {
+        return lodgeDateRepository.findById(lodgeDateId)
+                .orElseThrow(()-> new LodgeException(ErrorCode.LODGE_DATE_NOT_FOUND));
+    }
+
+    @Override
     public void create(
             Lodge lodge, LocalDate startDate, LocalDate endDate, List<LocalDate> excludeDates
     ) {
@@ -51,6 +57,7 @@ public class LodgeDateService {
         lodgeDateRepository.saveAll(lodgeDates);
     }
 
+    @Override
     public Slice<LodgeDateResponse> readAll(
             Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
     ) {
@@ -59,14 +66,11 @@ public class LodgeDateService {
                 .map(LodgeDateResponse::from);
     }
 
-    @Transactional
-    public void updateStatus(List<String> ids, String requestStatus) {
-        ReservationStatus status = ReservationStatus.fromString(requestStatus);
-        ids.forEach(id -> {
-            LodgeDate lodgeDate = lodgeDateRepository.findById(id)
-                    .orElseThrow(()-> new LodgeException(ErrorCode.LODGE_DATE_NOT_FOUND));
-            lodgeDate.updateStatus(status);
-        });
+    @Override
+    public void updateStatus(
+            LodgeDate lodgeDate, ReservationStatus status
+    ) {
+        lodgeDate.updateStatus(status);
     }
 
     /**

--- a/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeImageServiceImpl.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeImageServiceImpl.java
@@ -1,6 +1,7 @@
-package com.haot.lodge.application.service.Impl;
+package com.haot.lodge.application.service.implement;
 
 
+import com.haot.lodge.application.service.LodgeImageService;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.model.LodgeImage;
 import com.haot.lodge.domain.repository.LodgeImageRepository;
@@ -10,10 +11,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
-public class LodgeImageService {
+public class LodgeImageServiceImpl implements LodgeImageService {
 
     private final LodgeImageRepository lodgeImageRepository;
 
+    @Override
     public void create(
             Lodge lodge, MultipartFile file, String title, String description
     ) {

--- a/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeRuleServiceImpl.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeRuleServiceImpl.java
@@ -1,6 +1,7 @@
-package com.haot.lodge.application.service.Impl;
+package com.haot.lodge.application.service.implement;
 
 
+import com.haot.lodge.application.service.LodgeRuleService;
 import com.haot.lodge.common.exception.ErrorCode;
 import com.haot.lodge.common.exception.LodgeException;
 import com.haot.lodge.domain.model.Lodge;
@@ -12,11 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class LodgeRuleService {
+public class LodgeRuleServiceImpl implements LodgeRuleService {
 
     private final LodgeRuleRepository lodgeRuleRepository;
 
-    @Transactional
+    @Override
+    public LodgeRule getLodgeRuleByLodgeId(String lodgeId) {
+        return lodgeRuleRepository.findLodgeRuleByLodgeId(lodgeId)
+                .orElseThrow(()->new LodgeException(ErrorCode.LODGE_RULE_NOT_FOUND));
+    }
+
+    @Override
     public void create(
             Lodge linkedLodge, Integer maxReservationDay, Integer maxPersonnel, String customization
     ) {
@@ -25,8 +32,4 @@ public class LodgeRuleService {
         );
     }
 
-    public LodgeRule getLodgeRuleByLodgeId(String lodgeId) {
-        return lodgeRuleRepository.findLodgeRuleByLodgeId(lodgeId)
-                .orElseThrow(()->new LodgeException(ErrorCode.LODGE_RULE_NOT_FOUND));
-    }
 }

--- a/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeServiceImpl.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeServiceImpl.java
@@ -1,6 +1,7 @@
-package com.haot.lodge.application.service.Impl;
+package com.haot.lodge.application.service.implement;
 
 
+import com.haot.lodge.application.service.LodgeService;
 import com.haot.lodge.common.exception.ErrorCode;
 import com.haot.lodge.common.exception.LodgeException;
 import com.haot.lodge.domain.model.Lodge;
@@ -10,17 +11,20 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class LodgeBasicService {
+public class LodgeServiceImpl implements LodgeService {
 
     private final LodgeRepository lodgeRepository;
 
+    @Override
+    public Lodge getValidLodgeById(String lodgeId) {
+        return lodgeRepository.findById(lodgeId)
+                .orElseThrow(()->new LodgeException(ErrorCode.LODGE_NOT_FOUND));
+        // TODO: isDeleted = true 인 경우 제외되도록 해야 함
+    }
+
+    @Override
     public Lodge create(
-            String userId,
-            String name,
-            String description,
-            String address,
-            Integer term,
-            Double basicPrice
+            String userId, String name, String description, String address, Integer term, Double basicPrice
     ) {
         if(lodgeRepository.findByHostIdAndName(userId, name).isPresent()) {
             throw new LodgeException(ErrorCode.ALREADY_EXIST_LODGE_NAME);
@@ -28,12 +32,6 @@ public class LodgeBasicService {
         return lodgeRepository.save(Lodge.createLodge(
                 userId, name, description, address, term, basicPrice
         ));
-    }
-
-    public Lodge getLodgeById(String lodgeId) {
-        return lodgeRepository.findById(lodgeId)
-                .orElseThrow(()->new LodgeException(ErrorCode.LODGE_NOT_FOUND));
-        // TODO: isDeleted = true 인 경우 제외되도록 해야 함
     }
 
 }

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
@@ -3,9 +3,8 @@ package com.haot.lodge.presentation.controller;
 
 import com.haot.lodge.application.response.LodgeResponse;
 import com.haot.lodge.application.response.LodgeImageResponse;
-import com.haot.lodge.application.service.LodgeService;
+import com.haot.lodge.application.facade.LodgeFacade;
 import com.haot.lodge.presentation.response.LodgeReadAllResponse;
-import com.haot.lodge.application.response.LodgeRuleResponse;
 import com.haot.lodge.presentation.request.LodgeCreateRequest;
 import com.haot.lodge.presentation.request.LodgeUpdateRequest;
 import com.haot.lodge.common.response.ApiResponse;
@@ -34,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LodgeController {
 
-    private final LodgeService lodgeService;
+    private final LodgeFacade lodgeFacade;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
@@ -42,7 +41,7 @@ public class LodgeController {
             @Valid LodgeCreateRequest request
     ) {
         String userId = "UUID"; // 임시 유저 ID (Header 에서 가져오도록 수정 필요)
-        LodgeResponse lodge = lodgeService.createLodge(userId, request);
+        LodgeResponse lodge = lodgeFacade.createLodge(userId, request);
         return ApiResponse.success(new LodgeCreateResponse(lodge));
     }
 
@@ -88,7 +87,7 @@ public class LodgeController {
     public ApiResponse<LodgeReadOneResponse> readOne(
             @PathVariable String lodgeId
     ) {
-        return ApiResponse.success(lodgeService.readLodge(lodgeId));
+        return ApiResponse.success(lodgeFacade.readLodge(lodgeId));
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeDateController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeDateController.java
@@ -1,8 +1,9 @@
 package com.haot.lodge.presentation.controller;
 
 
-import com.haot.lodge.application.service.Impl.LodgeDateService;
-import com.haot.lodge.application.service.LodgeService;
+import com.haot.lodge.application.facade.LodgeDateFacade;
+import com.haot.lodge.application.service.implement.LodgeDateServiceImpl;
+import com.haot.lodge.application.facade.LodgeFacade;
 import com.haot.lodge.common.response.ApiResponse;
 import com.haot.lodge.presentation.request.LodgeDateUpdateRequest;
 import com.haot.lodge.presentation.request.LodgeDateUpdateStatusRequest;
@@ -31,8 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LodgeDateController {
 
-    private final LodgeService lodgeService;
-    private final LodgeDateService lodgeDateService;
+    private final LodgeDateFacade lodgeDateFacade;
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
@@ -45,7 +45,7 @@ public class LodgeDateController {
             @RequestParam(name = "end", required = false) LocalDate end
     ) {
         return ApiResponse.success(
-                lodgeService.readLodgeDates(pageable, lodgeId, start, end)
+                lodgeDateFacade.readLodgeDates(pageable, lodgeId, start, end)
         );
     }
 
@@ -63,7 +63,7 @@ public class LodgeDateController {
     public ApiResponse<Void> updateStatus(
             @Valid @RequestBody LodgeDateUpdateStatusRequest request
     ) {
-        lodgeDateService.updateStatus(request.lodgeDateIds(), request.status());
+        lodgeDateFacade.updateStatus(request.lodgeDateIds(), request.status());
         return ApiResponse.success();
     }
 


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #59  

Lodge의 서비스 패키지를 파사드 패턴을 적용해 분리했습니다.
- 분리 전: service 에서 여러 각 서비스 호출
- 패턴 적용: 상위의 facade 서비스가 여러 서비스를 호출. 컨트롤러는 해당 클래스만 사용
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 기존 서비스를 인터페이스와 구현체로 분리
- facade 패키지를 나눠 클래스를 생성했습니다. 
## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 프로젝트 정상 작동, 기존 API 호출시의 정상 작동을 확인했습니다.
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 기존에도 거의 파사드 패턴으로 하고 있긴 했는데 패키지명 나눠서 정확하게 분리했습니다.
- 기능이 많아질 것 같아서 application 하위에 lodge, lodgedate, lodgeimage 등으로 나누고 거기서 facade, response, service 나누는 것이 좋을 것 같다고 느끼긴 했는데 지금은 팀 컨벤션에 따라 application 하위 facade, response, service 로 나눴습니다! 추후 고민하고 더 리팩터링 해보겠습니다
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!