### PR TITLE
[Feat] Review: 리뷰 검색 API 구현

### DIFF
--- a/review/build.gradle
+++ b/review/build.gradle
@@ -58,6 +58,12 @@ dependencies {
 	// aop
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+	// querydsl
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	// implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 

--- a/review/src/main/java/com/haot/review/application/dtos/req/ReviewSearchRequest.java
+++ b/review/src/main/java/com/haot/review/application/dtos/req/ReviewSearchRequest.java
@@ -1,17 +1,13 @@
 package com.haot.review.application.dtos.req;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
-public class ReviewSearchRequest {
+public record ReviewSearchRequest(
+    String lodgeId,
 
-    private String lodgeId;
-
-    private String userId;
+    String userId,
     @JsonProperty("deleted")
-    private boolean isDeleted;
+    Boolean isDeleted
+) {
 
 }

--- a/review/src/main/java/com/haot/review/application/dtos/req/ReviewSearchRequest.java
+++ b/review/src/main/java/com/haot/review/application/dtos/req/ReviewSearchRequest.java
@@ -1,0 +1,17 @@
+package com.haot.review.application.dtos.req;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReviewSearchRequest {
+
+    private String lodgeId;
+
+    private String userId;
+    @JsonProperty("deleted")
+    private boolean isDeleted;
+
+}

--- a/review/src/main/java/com/haot/review/application/service/ReviewService.java
+++ b/review/src/main/java/com/haot/review/application/service/ReviewService.java
@@ -1,6 +1,7 @@
 package com.haot.review.application.service;
 
 import com.haot.review.application.dtos.req.ReviewCreateRequest;
+import com.haot.review.application.dtos.req.ReviewSearchRequest;
 import com.haot.review.application.dtos.req.ReviewUpdateRequest;
 import com.haot.review.application.dtos.res.ReviewGetResponse;
 import com.haot.review.common.exceptions.CustomReviewException;
@@ -13,6 +14,9 @@ import com.haot.review.presentation.client.LodgeClient;
 import com.haot.review.presentation.dto.LodgeReadOneResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +56,21 @@ public class ReviewService {
     return ReviewGetResponse.of(review);
   }
 
+  @Transactional(readOnly = true)
+  public Page<ReviewGetResponse> searchReview(String role, ReviewSearchRequest request, Pageable pageable) {
+
+    int pageSize = (pageable.getPageSize() == 30
+        || pageable.getPageSize() == 50)
+        ? pageable.getPageSize() : 10;
+
+    Pageable customPageable = PageRequest.of(
+        pageable.getPageNumber(),
+        pageSize,
+        pageable.getSort()
+    );
+
+    return reviewRepository.searchReview(role, request, customPageable).map(ReviewGetResponse::of);
+  }
 
   @Transactional
   public void updateReview(String reviewId, ReviewUpdateRequest request, String userId, String role) {
@@ -97,5 +116,4 @@ public class ReviewService {
     LodgeReadOneResponse response = lodgeClient.readOne(lodgeId).data();
     return hostId.equals(response.lodge().hostId());
   }
-
 }

--- a/review/src/main/java/com/haot/review/domain/repository/ReviewRepository.java
+++ b/review/src/main/java/com/haot/review/domain/repository/ReviewRepository.java
@@ -1,10 +1,11 @@
 package com.haot.review.domain.repository;
 
 import com.haot.review.domain.model.Review;
+import com.haot.review.infrastructure.repository.ReviewRepositoryCustom;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReviewRepository extends JpaRepository<Review, String> {
+public interface ReviewRepository extends JpaRepository<Review, String>, ReviewRepositoryCustom {
 
   Optional<Review> findByReviewIdAndIsDeletedFalse(String reviewId);
 

--- a/review/src/main/java/com/haot/review/infrastructure/configuration/QueryDslConfig.java
+++ b/review/src/main/java/com/haot/review/infrastructure/configuration/QueryDslConfig.java
@@ -1,0 +1,16 @@
+package com.haot.review.infrastructure.configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueryDslConfig {
+
+  @Bean
+  JPAQueryFactory jpaQueryFactory(EntityManager em) {
+    return new JPAQueryFactory(em);
+  }
+
+}

--- a/review/src/main/java/com/haot/review/infrastructure/repository/ReviewRepositoryCustom.java
+++ b/review/src/main/java/com/haot/review/infrastructure/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.haot.review.infrastructure.repository;
+
+
+import com.haot.review.application.dtos.req.ReviewSearchRequest;
+import com.haot.review.domain.model.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewRepositoryCustom {
+
+  Page<Review> searchReview(String role, ReviewSearchRequest request, Pageable pageable);
+
+}

--- a/review/src/main/java/com/haot/review/infrastructure/repository/ReviewRepositoryCustomImpl.java
+++ b/review/src/main/java/com/haot/review/infrastructure/repository/ReviewRepositoryCustomImpl.java
@@ -48,8 +48,8 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
 
   private BooleanBuilder conditions(String role, ReviewSearchRequest request) {
     BooleanBuilder builder = new BooleanBuilder()
-        .and(lodgeIdEq(request.getLodgeId()))
-        .and(userIdEq(request.getUserId()));
+        .and(lodgeIdEq(request.lodgeId()))
+        .and(userIdEq(request.userId()));
 
     if ("MASTER".equals(role) || "HOST".equals(role)) {
       builder.and(deletedEq(request.isDeleted()));

--- a/review/src/main/java/com/haot/review/infrastructure/repository/ReviewRepositoryCustomImpl.java
+++ b/review/src/main/java/com/haot/review/infrastructure/repository/ReviewRepositoryCustomImpl.java
@@ -1,0 +1,89 @@
+package com.haot.review.infrastructure.repository;
+
+
+import com.haot.review.application.dtos.req.ReviewSearchRequest;
+import com.haot.review.domain.model.QReview;
+import com.haot.review.domain.model.Review;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+  QReview review = QReview.review;
+
+  @Override
+  public Page<Review> searchReview(String role, ReviewSearchRequest request, Pageable pageable) {
+
+    JPAQuery<Review> query = queryFactory.selectFrom(review)
+        .where(conditions(role, request))
+        .orderBy(getOrderSpecifiers(pageable))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize());
+
+    long total = Optional.ofNullable(queryFactory
+            .select(review.count())
+            .from(review)
+            .where(conditions(role, request))
+            .fetchOne())
+        .orElseThrow();
+
+    List<Review> content = query.stream().toList();
+
+    return new PageImpl<>(content, pageable, total);
+  }
+
+
+  private BooleanBuilder conditions(String role, ReviewSearchRequest request) {
+    BooleanBuilder builder = new BooleanBuilder()
+        .and(lodgeIdEq(request.getLodgeId()))
+        .and(userIdEq(request.getUserId()));
+
+    if ("MASTER".equals(role) || "HOST".equals(role)) {
+      builder.and(deletedEq(request.isDeleted()));
+    } else {
+      builder.and(review.isDeleted.isFalse());
+    }
+    return builder;
+  }
+
+  private BooleanExpression lodgeIdEq(String lodgeId) {
+    return lodgeId != null ? review.lodgeId.eq(lodgeId) : null;
+  }
+
+  private BooleanExpression userIdEq(String userId) {
+    return userId != null ? review.userId.eq(userId) : null;
+  }
+
+  private BooleanExpression deletedEq(Boolean isDeleted) {
+    return isDeleted != null ? review.isDeleted.eq(isDeleted) : null;
+  }
+
+  private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+    return pageable.getSort().stream()
+        .map(order -> {
+          String property = order.getProperty();
+          boolean isAscending = order.isAscending();
+          return switch (property) {
+            case "createdAt" -> isAscending ? review.createdAt.asc() : review.createdAt.desc();
+            case "updatedAt" -> isAscending ? review.updatedAt.asc() : review.updatedAt.desc();
+            case "lodgeId" -> isAscending ? review.lodgeId.asc() : review.lodgeId.desc();
+            case "userId" -> isAscending ? review.userId.asc() : review.userId.desc();
+            default -> review.createdAt.asc();
+          };
+        })
+        .toArray(OrderSpecifier<?>[]::new);
+  }
+}

--- a/review/src/main/java/com/haot/review/presentation/controller/ReviewController.java
+++ b/review/src/main/java/com/haot/review/presentation/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.haot.review.presentation.controller;
 
 
 import com.haot.review.application.dtos.req.ReviewCreateRequest;
+import com.haot.review.application.dtos.req.ReviewSearchRequest;
 import com.haot.review.application.dtos.req.ReviewUpdateRequest;
 import com.haot.review.application.dtos.res.ReviewGetResponse;
 import com.haot.review.application.service.ReviewService;
@@ -9,6 +10,8 @@ import com.haot.review.common.response.ApiResponse;
 import com.haot.review.common.response.enums.SuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,6 +47,16 @@ public class ReviewController {
       @PathVariable String reviewId
   ) {
     return ApiResponse.success(reviewService.readOne(reviewId));
+  }
+
+  @ResponseStatus(HttpStatus.OK)
+  @GetMapping
+  public ApiResponse<Page<ReviewGetResponse>> search(
+      @RequestHeader(value = "X-Role", required = true) String role,
+      ReviewSearchRequest request,
+      Pageable pageable
+  ) {
+    return ApiResponse.success(reviewService.searchReview(role, request, pageable));
   }
 
   @ResponseStatus(HttpStatus.OK)


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #107  
- 리뷰 검색 API 구현

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 권한에 따라 데이터 조회 (삭제된 데이터)
- record 로 dto 작성하니 검색 조건에 bool(idDeleted) 타입이 null이 올수 없는 문제로 ReviewSearchRequest 는 class 로 작성했습니다. 이후에 해결 방법을 찾아보겠습니다
- 정렬 조건 ( 생성일, 수정일, 숙소 아이디, 유저 아이디)

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
![스크린샷 2025-01-10 002857](https://github.com/user-attachments/assets/9f4c7117-4435-46c4-97bb-e56c82859810)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 앤드포인트에 따라 권한으로 조회하는 로직이 달라야하지만.. 현재 리뷰에서는 isDelete 로직 하나만 추가됩니다. 
- 컨트롤러, qdsl 메서드를 생성해야하는데 로직이 한줄 이외로는 동일해서 일단은 하나로 만들었습니다.
- mvp 구현 이후에 분리하도록 하겠습니다 
- 개선할 부분 리뷰 부탁드립니다.
