### PR TITLE
[Feat] Point: 포인트 상태 변경 API 구현

### DIFF
--- a/point/src/main/java/com/haot/point/application/dto/request/PointStatusRequest.java
+++ b/point/src/main/java/com/haot/point/application/dto/request/PointStatusRequest.java
@@ -3,6 +3,8 @@ package com.haot.point.application.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record PointStatusRequest(
-        @NotBlank String contextId
+        @NotBlank String contextId,
+        @NotBlank String status,
+        String cancelType
 ) {
 }

--- a/point/src/main/java/com/haot/point/application/service/PointHistoryService.java
+++ b/point/src/main/java/com/haot/point/application/service/PointHistoryService.java
@@ -1,0 +1,10 @@
+package com.haot.point.application.service;
+
+import com.haot.point.application.dto.request.PointStatusRequest;
+import com.haot.point.application.dto.response.PointAllResponse;
+
+public interface PointHistoryService {
+
+    // 포인트 상태 변경
+    PointAllResponse updateStatusPoint(PointStatusRequest request, String historyId);
+}

--- a/point/src/main/java/com/haot/point/application/service/PointHistoryServiceImpl.java
+++ b/point/src/main/java/com/haot/point/application/service/PointHistoryServiceImpl.java
@@ -1,0 +1,120 @@
+package com.haot.point.application.service;
+
+import com.haot.point.application.dto.request.PointStatusRequest;
+import com.haot.point.application.dto.response.PointAllResponse;
+import com.haot.point.common.exception.CustomPointException;
+import com.haot.point.common.exception.enums.ErrorCode;
+import com.haot.point.domain.enums.PointStatus;
+import com.haot.point.domain.enums.PointType;
+import com.haot.point.domain.model.Point;
+import com.haot.point.domain.model.PointHistory;
+import com.haot.point.infrastructure.repository.PointHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j(topic = "PointHistoryServiceImpl")
+@Service
+@RequiredArgsConstructor
+public class PointHistoryServiceImpl implements PointHistoryService {
+
+    private final PointHistoryRepository pointHistoryRepository;
+
+    @Override
+    @Transactional
+    public PointAllResponse updateStatusPoint(PointStatusRequest request, String historyId) {
+
+        // 1. 기존 point 내역 조회
+        PointHistory pointHistory = pointHistoryRepository.findByIdAndIsDeletedFalse(historyId)
+                .orElseThrow(() -> new CustomPointException(ErrorCode.POINT_NOT_FOUND));
+        Point point = pointHistory.getPoint();
+
+        // 2. 현재 상태가 ROLLBACK 또는 CANCELLED 인 경우 상태 전이 불가
+        if (pointHistory.getStatus().equals(PointStatus.ROLLBACK) || pointHistory.getStatus().equals(PointStatus.CANCELLED)) {
+            throw new CustomPointException(ErrorCode.POINT_CHANGE_NOT_SUPPORTED);
+        }
+
+        // 3. status 유효성 검사 및 상태 변경 가능 여부 검증
+        PointStatus status = PointStatus.fromString(request.status());
+        // PENDING 상태에서 cancelType 은 null 이어야 함 -> 취소 요청 불가
+        if (pointHistory.getStatus().equals(PointStatus.PENDING) && request.cancelType() != null) {
+            throw new CustomPointException(ErrorCode.PENDING_OPERATION_EXISTS);
+        }
+        // CANCELLED 와 PENDING 상태는 외부에서 요청 불가
+        if (status.equals(PointStatus.CANCELLED) || status.equals(PointStatus.PENDING)) {
+            throw new CustomPointException(ErrorCode.POINT_CHANGE_NOT_SUPPORTED);
+        }
+
+        // 4. 요청 type, status 에 따른 처리 - 1) 취소 요청에 대한 처리
+        // cancelType != null && status == PROCESSED
+        if (request.cancelType() != null) {
+            PointType cancelType = PointType.fromString(request.cancelType());
+
+            // (1) USE 타입에선 CANCEL_USE 만 허용
+            if (pointHistory.getType().equals(PointType.USE) && !cancelType.equals(PointType.CANCEL_USE)) {
+                throw new CustomPointException(ErrorCode.INVALID_CANCEL_TYPE_FOR_USE);
+            }
+            // (2) EARN 타입에선 CANCEL_EARN 만 허용
+            if (pointHistory.getType().equals(PointType.EARN) && !cancelType.equals(PointType.CANCEL_EARN)) {
+                throw new CustomPointException(ErrorCode.INVALID_CANCEL_TYPE_FOR_EARN);
+            }
+            // (3) cancelType 과 ROLLBACK 조합은 허용하지 않음
+            if (status.equals(PointStatus.ROLLBACK)) {
+                throw new CustomPointException(ErrorCode.INVALID_REQUEST_COMBINATION);
+            }
+            // 새로운 취소 데이터 생성
+            return createCancelData(point, pointHistory, cancelType, request.contextId());
+        }
+
+        // 4. 요청 type, status 에 따른 처리 - 2) 실패로 인한 롤백
+        // cancelType == null && status == ROLLBACK
+        if (status.equals(PointStatus.ROLLBACK)) {
+            handleRollback(point, pointHistory);
+        }
+
+        // 4. 요청 type, status 에 따른 처리 - 3) 단순 상태 변경
+        // cancelType == null && status == PROCESSED
+        String description = PointType.createDescription(request.contextId(), pointHistory.getType());
+        pointHistory.updateStatus(description, status);
+
+        return PointAllResponse.of(point, pointHistory);
+    }
+
+    // 타입에 따른 롤백 처리 로직
+    private void handleRollback(Point point, PointHistory pointHistory) {
+        switch (pointHistory.getType()) {
+            // 포인트 복원, 적립 차감 복원
+            case USE, CANCEL_EARN ->
+                    point.updateTotalPoint(point.getTotalPoints() + pointHistory.getPoints());
+            // 적립된 포인트 차감, 사용 복원 취소
+            case EARN, CANCEL_USE ->
+                    point.updateTotalPoint(point.getTotalPoints() - pointHistory.getPoints());
+            default -> throw new CustomPointException(ErrorCode.POINT_TYPE_NOT_SUPPORTED);
+        }
+    }
+
+    // 취소 데이터 생성
+    private PointAllResponse createCancelData(Point point, PointHistory pointHistory, PointType pointType, String contextId) {
+        // 기존 포인트 내역 상태 ROLLBACK 으로 변경
+        pointHistory.updateStatus(null, PointStatus.CANCELLED);
+        PointHistory cancelHistory = PointHistory.create(
+                point,
+                pointHistory.getPoints(), // 기존 포인트 값 사용
+                pointType,
+                PointType.createDescription(contextId, pointType),
+                null,
+                PointStatus.PROCESSED
+        );
+        pointHistoryRepository.save(cancelHistory);
+
+        // 포인트 업데이트
+        if (pointType.equals(PointType.CANCEL_USE)) {
+            point.updateTotalPoint(point.getTotalPoints() + cancelHistory.getPoints()); // 복원
+        } else if (pointType.equals(PointType.CANCEL_EARN)) {
+            point.updateTotalPoint(point.getTotalPoints() - cancelHistory.getPoints()); // 차감
+        }
+
+        return PointAllResponse.of(point, cancelHistory);
+    }
+}

--- a/point/src/main/java/com/haot/point/application/service/PointServiceImpl.java
+++ b/point/src/main/java/com/haot/point/application/service/PointServiceImpl.java
@@ -59,7 +59,7 @@ public class PointServiceImpl implements PointService{
 
         // 1. 포인트 타입 유효성 검사
         PointType type = PointType.fromString(request.type());
-        if (!(type.equals(PointType.USE) || type.equals(PointType.REFUND))) {
+        if (!(type.equals(PointType.USE))) {
             throw new CustomPointException(ErrorCode.POINT_TYPE_NOT_SUPPORTED);
         }
 
@@ -90,12 +90,6 @@ public class PointServiceImpl implements PointService{
         pointHistoryRepository.save(pointHistory);
 
         return PointAllResponse.of(point, pointHistory);
-    }
-
-
-    // 포인트 설명 생성
-    public String createDescription(String contextId, PointType type) {
-        return contextId + " " + type.getDescription() + " 포인트";
     }
 
     private Point validPoint(String pointId) {

--- a/point/src/main/java/com/haot/point/common/exception/enums/ErrorCode.java
+++ b/point/src/main/java/com/haot/point/common/exception/enums/ErrorCode.java
@@ -29,7 +29,13 @@ public enum ErrorCode implements ResCodeIfs {
     POINT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "9005", "포인트 내역 정보를 찾을 수 없습니다."),
     POINT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "9006", "이미 처리된 포인트 입니다." ),
     POINT_CONTEXID_REQUIRED(HttpStatus.BAD_REQUEST, "9007", "요청에 contextId 정보가 필요합니다."),
-    PENDING_OPERATION_EXISTS(HttpStatus.BAD_REQUEST, "9008", "현재 처리 중인 포인트가 있어 요청을 수행할 수 없습니다.");
+    PENDING_OPERATION_EXISTS(HttpStatus.BAD_REQUEST, "9008", "현재 처리 중인 포인트가 있어 요청을 수행할 수 없습니다."),
+    POINT_CANCEL_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "9009", "취소 포인트 형식만 입력 가능합니다."),
+    INVALID_REQUEST_COMBINATION(HttpStatus.BAD_REQUEST, "9010", "ROLLBACK 은 Type 요청이 불가능합니다."),
+    POINT_CHANGE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "9011", "지원하지 않는 포인트 상태 변경입니다."),
+    INVALID_CANCEL_TYPE_FOR_USE(HttpStatus.BAD_REQUEST, "9012", "USE 상태에서는 CANCEL_USE 만 허용됩니다."),
+    INVALID_CANCEL_TYPE_FOR_EARN(HttpStatus.BAD_REQUEST, "9013", "EARN 상태에서는 CANCEL_EARN 만 허용됩니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/point/src/main/java/com/haot/point/domain/enums/PointStatus.java
+++ b/point/src/main/java/com/haot/point/domain/enums/PointStatus.java
@@ -11,7 +11,9 @@ import java.util.Arrays;
 @AllArgsConstructor
 public enum PointStatus {
     PENDING("포인트 처리 대기 상태"),
-    PROCESSED("포인트 처리 완료 상태");
+    PROCESSED("포인트 처리 완료 상태"),
+    ROLLBACK("포인트 롤백 상태"),
+    CANCELLED("포인트 적립/사용이 취소된 상태");
 
     private final String description;
 

--- a/point/src/main/java/com/haot/point/domain/enums/PointType.java
+++ b/point/src/main/java/com/haot/point/domain/enums/PointType.java
@@ -12,7 +12,8 @@ import java.util.Arrays;
 public enum PointType {
     EARN("포인트 적립"),
     USE("포인트 사용"),
-    REFUND("포인트 환불"),
+    CANCEL_EARN("예약 취소로 인한 적립 포인트 차감"),
+    CANCEL_USE("예약 취소로 인한 사용 포인트 적립"),
     EXPIRE("포인트 만료");
 
     private final String description;
@@ -22,5 +23,9 @@ public enum PointType {
                 .filter(enumValue -> enumValue.name().equalsIgnoreCase(type))   // 대소문자 구분 X
                 .findFirst()
                 .orElseThrow(() -> new CustomPointException(ErrorCode.POINT_TYPE_NOT_SUPPORTED));
+    }
+
+    public static String createDescription(String contextId, PointType type) {
+        return contextId + " " + type.getDescription();
     }
 }

--- a/point/src/main/java/com/haot/point/domain/model/PointHistory.java
+++ b/point/src/main/java/com/haot/point/domain/model/PointHistory.java
@@ -56,4 +56,11 @@ public class PointHistory extends BaseEntity{
                 .status(status)
                 .build();
     }
+
+    public void updateStatus(String description, PointStatus status) {
+        if (description != null) {
+            this.description = description;
+        }
+        this.status = status;
+    }
 }

--- a/point/src/main/java/com/haot/point/infrastructure/repository/PointHistoryRepository.java
+++ b/point/src/main/java/com/haot/point/infrastructure/repository/PointHistoryRepository.java
@@ -11,4 +11,5 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Stri
    @Query("SELECT ph FROM PointHistory ph WHERE ph.point.id = :pointId AND ph.status = 'PENDING'")
     Optional<PointHistory> findPendingHistory(@Param("pointId") String pointId);
 
+    Optional<PointHistory> findByIdAndIsDeletedFalse(String historyId);
 }

--- a/point/src/main/java/com/haot/point/presentation/controller/PointHistoryController.java
+++ b/point/src/main/java/com/haot/point/presentation/controller/PointHistoryController.java
@@ -3,8 +3,10 @@ package com.haot.point.presentation.controller;
 import com.haot.point.application.dto.request.PointStatusRequest;
 import com.haot.point.application.dto.response.PointAllResponse;
 import com.haot.point.application.dto.response.PointHistoryResponse;
+import com.haot.point.application.service.PointHistoryService;
 import com.haot.point.common.response.ApiResponse;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -16,7 +18,10 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/points/histories")
+@RequiredArgsConstructor
 public class PointHistoryController {
+
+    private final PointHistoryService pointHistoryService;
 
     // 본인 포인트 내역 조회
     @GetMapping("/{historyId}")
@@ -72,21 +77,9 @@ public class PointHistoryController {
     // 포인트 상태 변경
     @PostMapping("/{historyId}/status")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<PointAllResponse> changeStatusPoint(@Valid @RequestBody PointStatusRequest request,
+    public ApiResponse<PointAllResponse> updateStatusPoint(@Valid @RequestBody PointStatusRequest request,
                                                            @PathVariable String historyId) {
-        return ApiResponse.success(
-                new PointAllResponse(
-                        "POINT-UUID",
-                        historyId,
-                        "USER-UUID",
-                        1000.0,
-                        1000.0,
-                        "USE",
-                        "RESERVATION-UUID USE POINT",
-                        LocalDateTime.now().plusMonths(3),
-                        request.status()
-                )
-        );
+        return ApiResponse.success(pointHistoryService.updateStatusPoint(request, historyId));
     }
 
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #100 
- 포인트 상태 변경 구현

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 포인트 상태 변경 API 구현
- 포인트 적립/차감 취소, 롤백도 상태 변경 API 로 가능하도록 구현
- type, status 에 따라 로직 다르게 구현

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 흐름 정리하면서 작성한 노션입니다! 안에 테스트 결과도 있으니 참고하시면 될 것 같아요
https://www.notion.so/3484bb5858314a7cbb365f77c535f03f?pvs=23

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 포인트 유형 세분화 및 포인트 상태 추가, 요청값 변경을 하여 명세서에 반영해두었습니다!
- 하다보니 취소랑 롤백도 같이 적용되게 구현하게 돼서 조건들이 많아졌는데,,, API 를 다르게 두는 것도 애매한 것 같고,,, 적용한 김에 그냥 하자 생각돼서 같이 적용했습니다.... 만약 리팩토링이 필요하다고 판단되면 추후에 변경하도록 하겠습니다....