### PR TITLE
[feat] 내 쿠폰함 조회 API 구현

### DIFF
--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 	// PostgreSql
 	runtimeOnly 'org.postgresql:postgresql'
 
+	//Spring AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/coupon/src/main/java/com/haot/coupon/application/dto/response/coupons/CouponReadMeResponse.java
+++ b/coupon/src/main/java/com/haot/coupon/application/dto/response/coupons/CouponReadMeResponse.java
@@ -1,17 +1,18 @@
 package com.haot.coupon.application.dto.response.coupons;
 
-import com.haot.coupon.domain.model.enums.CouponStatus;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder
 public record CouponReadMeResponse(
-
-        String userCouponId,
+        String couponId,
         String couponName,
         LocalDateTime couponAvailableDate,
         LocalDateTime couponExpiredDate,
-        CouponStatus couponStatus
+        double minAvailableAmount, // 최소 사용 금액
+        double maxAvailableAMount, // 쿠폰 최대 사용할 수 있는 금액
+        Integer discountRate,   // 할인율
+        Double discountAmount   // 할인 금액
 ) {
 }

--- a/coupon/src/main/java/com/haot/coupon/application/mapper/UserCouponMapper.java
+++ b/coupon/src/main/java/com/haot/coupon/application/mapper/UserCouponMapper.java
@@ -1,5 +1,6 @@
 package com.haot.coupon.application.mapper;
 
+import com.haot.coupon.application.dto.response.coupons.CouponReadMeResponse;
 import com.haot.coupon.domain.model.Coupon;
 import com.haot.coupon.domain.model.UserCoupon;
 import org.mapstruct.Mapper;
@@ -13,6 +14,16 @@ public interface UserCouponMapper {
     @Mapping(target = "usedDate", ignore = true)
     @Mapping(target = "isDelete", ignore = true)
     UserCoupon toEntity(String userId, Coupon coupon);
+
+    @Mapping(source = "coupon.id", target = "couponId")
+    @Mapping(source = "coupon.name", target = "couponName")
+    @Mapping(source = "coupon.availableDate", target = "couponAvailableDate")
+    @Mapping(source = "coupon.expiredDate", target = "couponExpiredDate")
+    @Mapping(source = "coupon.minAvailableAmount", target = "minAvailableAmount")
+    @Mapping(source = "coupon.maxAvailableAmount", target = "maxAvailableAMount")
+    @Mapping(source = "coupon.discountRate.rate", target = "discountRate")
+    @Mapping(source = "coupon.discountAmount", target = "discountAmount")
+    CouponReadMeResponse toCouponReadMeResponse(UserCoupon userCoupon);
 
 
 }

--- a/coupon/src/main/java/com/haot/coupon/application/service/CouponService.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/CouponService.java
@@ -3,9 +3,12 @@ package com.haot.coupon.application.service;
 import com.haot.coupon.application.dto.feign.request.FeignConfirmReservationRequest;
 import com.haot.coupon.application.dto.feign.request.FeignVerifyRequest;
 import com.haot.coupon.application.dto.request.coupons.CouponCustomerCreateRequest;
+import com.haot.coupon.application.dto.response.coupons.CouponReadMeResponse;
 import com.haot.coupon.application.dto.response.coupons.CouponSearchResponse;
 import com.haot.coupon.application.dto.feign.response.ReservationVerifyResponse;
 import com.haot.coupon.domain.model.enums.EventStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CouponService {
     void customerIssueCoupon(CouponCustomerCreateRequest request, String userId);
@@ -17,4 +20,6 @@ public interface CouponService {
     ReservationVerifyResponse verify(FeignVerifyRequest request);
 
     void confirmReservation(String reservationCouponId, FeignConfirmReservationRequest request);
+
+    Page<CouponReadMeResponse> getMyCoupons(String userId, Pageable pageable);
 }

--- a/coupon/src/main/java/com/haot/coupon/application/service/impl/CouponServiceImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/impl/CouponServiceImpl.java
@@ -36,8 +36,6 @@ public class CouponServiceImpl implements CouponService {
     private final UserCouponRepository userCouponRepository;
     private final ReservationCouponRepository reservationCouponRepository;
 
-    private final UserCouponCustomRepository userCouponCustomRepository;
-
     private final CouponMapper couponMapper;
     private final UserCouponMapper userCouponMapper;
     private final ReservationCouponMapper reservationCouponMapper;
@@ -137,7 +135,7 @@ public class CouponServiceImpl implements CouponService {
     @Transactional(readOnly = true)
     @Override
     public Page<CouponReadMeResponse> getMyCoupons(String userId, Pageable pageable) {
-        return userCouponCustomRepository.checkMyCouponBox(userId, pageable);
+        return userCouponRepository.checkMyCouponBox(userId, pageable);
     }
 
     // 선점 상태 검증

--- a/coupon/src/main/java/com/haot/coupon/application/service/impl/CouponServiceImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/impl/CouponServiceImpl.java
@@ -3,6 +3,7 @@ package com.haot.coupon.application.service.impl;
 import com.haot.coupon.application.dto.feign.request.FeignConfirmReservationRequest;
 import com.haot.coupon.application.dto.feign.request.FeignVerifyRequest;
 import com.haot.coupon.application.dto.request.coupons.CouponCustomerCreateRequest;
+import com.haot.coupon.application.dto.response.coupons.CouponReadMeResponse;
 import com.haot.coupon.application.dto.response.coupons.CouponSearchResponse;
 import com.haot.coupon.application.dto.feign.response.ReservationVerifyResponse;
 import com.haot.coupon.application.kafka.CouponErrorProducer;
@@ -17,11 +18,10 @@ import com.haot.coupon.domain.model.CouponEvent;
 import com.haot.coupon.domain.model.ReservationCoupon;
 import com.haot.coupon.domain.model.UserCoupon;
 import com.haot.coupon.domain.model.enums.*;
-import com.haot.coupon.infrastructure.repository.CouponEventRepository;
-import com.haot.coupon.infrastructure.repository.CouponRepository;
-import com.haot.coupon.infrastructure.repository.ReservationCouponRepository;
-import com.haot.coupon.infrastructure.repository.UserCouponRepository;
+import com.haot.coupon.infrastructure.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +35,8 @@ public class CouponServiceImpl implements CouponService {
     private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
     private final ReservationCouponRepository reservationCouponRepository;
+
+    private final UserCouponCustomRepository userCouponCustomRepository;
 
     private final CouponMapper couponMapper;
     private final UserCouponMapper userCouponMapper;
@@ -130,6 +132,12 @@ public class CouponServiceImpl implements CouponService {
 
         // 예약 상태 처리
         handleReservation(reservationCoupon, reservationCouponStatus);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<CouponReadMeResponse> getMyCoupons(String userId, Pageable pageable) {
+        return userCouponCustomRepository.checkMyCouponBox(userId, pageable);
     }
 
     // 선점 상태 검증

--- a/coupon/src/main/java/com/haot/coupon/common/response/enums/ErrorCode.java
+++ b/coupon/src/main/java/com/haot/coupon/common/response/enums/ErrorCode.java
@@ -42,8 +42,13 @@ public enum ErrorCode implements ResCodeIfs {
     RESERVATION_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "4025", "ReservationCoupon not found."),
     RESERVATION_COUPON_NOT_PREEMPTED(HttpStatus.NOT_FOUND, "4026", "선점된 쿠폰이 아닙니다"),
 
+    // service common Error
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "4500", "지원하지 않는 정렬 방식입니다."),
+
+    // 4900 ~ front 단에 같이 나가게 되는 Error
     CURRENT_EVENT_CLOSED(HttpStatus.CONFLICT, "4900", "이벤트가 이미 종료되었습니다."),
     CURRENT_EVENT_END_TO_OUT_OF_STOCK(HttpStatus.CONFLICT, "4910", "쿠폰 재고 마감으로 인해 이벤트가 종료되었습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/coupon/src/main/java/com/haot/coupon/common/response/enums/SuccessCode.java
+++ b/coupon/src/main/java/com/haot/coupon/common/response/enums/SuccessCode.java
@@ -13,10 +13,11 @@ public enum SuccessCode implements ResCodeIfs {
     CREATE_COUPON_SUCCESS(HttpStatus.CREATED, "4000", "쿠폰이 성공적으로 생성되었습니다."),
     CUSTOMER_ISSUED_COUPON_SUCCESS(HttpStatus.OK, "4000", "사용자가 쿠폰을 성공적으로 발급하였습니다."),
     GET_DETAIL_COUPON_SUCCESS(HttpStatus.OK, "4000", "쿠폰 상세조회 성공하였습니다."),
-    COUPON_RESERVATION_SUCCESS(HttpStatus.OK, "4000", "쿠폰 상태 변경 성공하였습니다."),
+    GET_USER_COUPONS_SUCCESS(HttpStatus.OK, "4000", "쿠폰함 조회 성공했습니다."),
 
-    // 쿠폰 Feign
+    // 쿠폰 Feign,
     VERIFY_COUPON_SUCCESS(HttpStatus.OK, "4000", "쿠폰 유효성 검사 성공하였습니다."),
+    COUPON_RESERVATION_SUCCESS(HttpStatus.OK, "4000", "쿠폰 상태 변경 성공하였습니다."),
 
     // 이벤트
     CREATE_EVENT_SUCCESS(HttpStatus.CREATED, "4000", "이벤트가 성공적으로 생성되었습니다."),

--- a/coupon/src/main/java/com/haot/coupon/domain/utils/QueryDslSortUtils.java
+++ b/coupon/src/main/java/com/haot/coupon/domain/utils/QueryDslSortUtils.java
@@ -1,0 +1,33 @@
+package com.haot.coupon.domain.utils;
+
+import com.haot.coupon.common.exceptions.CustomCouponException;
+import com.haot.coupon.common.response.enums.ErrorCode;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Map;
+
+public class QueryDslSortUtils {
+
+    public static OrderSpecifier<?>[] getOrderSpecifiers(
+            Pageable pageable,
+            Map<String, ComparableExpressionBase<?>> sortPaths
+    ) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    ComparableExpressionBase<?> sortPath = sortPaths.get(order.getProperty());
+                    if (sortPath == null) {
+                        throw new CustomCouponException(ErrorCode.UNSUPPORTED_SORT_TYPE);
+                    }
+                    return new OrderSpecifier<>(
+                            order.isAscending()
+                                    ? com.querydsl.core.types.Order.ASC
+                                    : com.querydsl.core.types.Order.DESC,
+                            sortPath
+                    );
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+}

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslConfig.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslConfig.java
@@ -1,7 +1,5 @@
 package com.haot.coupon.infrastructure.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.context.annotation.Bean;

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslConfig.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,25 @@
+package com.haot.coupon.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule()); // LocalDateTime 처리
+        return mapper;
+    }
+
+}

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslConfig.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslConfig.java
@@ -15,11 +15,4 @@ public class QueryDslConfig {
         return new JPAQueryFactory(entityManager);
     }
 
-    @Bean
-    public ObjectMapper objectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule()); // LocalDateTime 처리
-        return mapper;
-    }
-
 }

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslPageableConfig.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslPageableConfig.java
@@ -1,0 +1,16 @@
+package com.haot.coupon.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class QueryDslPageableConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new QueryDslPageableResolver());
+    }
+}

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslPageableResolver.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/config/QueryDslPageableResolver.java
@@ -1,0 +1,58 @@
+package com.haot.coupon.infrastructure.config;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+public class QueryDslPageableResolver extends PageableHandlerMethodArgumentResolver {
+
+    public static final List<Integer> ALLOWED_PAGE_SIZES = Arrays.asList(10, 30, 50);
+    public static final int DEFAULT_PAGE_SIZE = 10;
+    public static final Sort DEFAULT_SORT = Sort.by(Sort.Direction.DESC, "createdAt");
+
+    @Override
+    public Pageable resolveArgument(MethodParameter methodParameter,
+                                    ModelAndViewContainer mavContainer,
+                                    NativeWebRequest webRequest,
+                                    WebDataBinderFactory binderFactory) {
+        Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+
+        return validate(pageable, this::validatePageNumber, this::validatePageSize, this::validateSort);
+    }
+
+    private Pageable validate(Pageable pageable,
+                              Function<Integer, Integer> pageNumberValidator,
+                              Function<Integer, Integer> pageSizeValidator,
+                              Function<Sort, Sort> sortValidator) {
+        int pageNumber = pageNumberValidator.apply(pageable.getPageNumber());
+        int pageSize = pageSizeValidator.apply(pageable.getPageSize());
+        Sort sort = sortValidator.apply(pageable.getSort());
+
+        return PageRequest.of(pageNumber, pageSize, sort);
+    }
+
+    // 음수가 오면 0이 기본값
+    private Integer validatePageNumber(int pageNumber) {
+        return Math.max(pageNumber, 0);
+    }
+
+    // 10, 30, 50이 아니면 -> 기본값 10
+    private Integer validatePageSize(int pageSize) {
+        return ALLOWED_PAGE_SIZES.contains(pageSize) ? pageSize : DEFAULT_PAGE_SIZE;
+    }
+
+    // sort 객체가 없으면 createdAt desc
+    private Sort validateSort(Sort sort) {
+        return sort.isSorted() ? sort : DEFAULT_SORT;
+    }
+}
+

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/UserCouponCustomRepository.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/UserCouponCustomRepository.java
@@ -1,0 +1,9 @@
+package com.haot.coupon.infrastructure.repository;
+
+import com.haot.coupon.application.dto.response.coupons.CouponReadMeResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserCouponCustomRepository {
+    Page<CouponReadMeResponse> checkMyCouponBox(String userId, Pageable pageable);
+}

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/UserCouponRepository.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/UserCouponRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserCouponRepository extends JpaRepository<UserCoupon, String> {
+public interface UserCouponRepository extends JpaRepository<UserCoupon, String>, UserCouponCustomRepository {
     boolean existsByUserIdAndCouponIdAndIsDeleteFalse(String userId, String couponId);
 
     Optional<UserCoupon> findByUserIdAndCouponIdAndIsDeleteFalse(String userId, String couponId);

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/impl/UserCouponCustomRepositoryImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/impl/UserCouponCustomRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.haot.coupon.infrastructure.repository.impl;
+
+import com.haot.coupon.application.dto.response.coupons.CouponReadMeResponse;
+import com.haot.coupon.application.mapper.UserCouponMapper;
+import com.haot.coupon.domain.model.QCoupon;
+import com.haot.coupon.domain.model.QUserCoupon;
+import com.haot.coupon.domain.model.UserCoupon;
+import com.haot.coupon.infrastructure.repository.UserCouponCustomRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class UserCouponCustomRepositoryImpl implements UserCouponCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final UserCouponMapper userCouponMapper;
+
+    QCoupon coupon = QCoupon.coupon;
+    QUserCoupon userCoupon = QUserCoupon.userCoupon;
+
+    @Override
+    public Page<CouponReadMeResponse> checkMyCouponBox(String userId, Pageable pageable) {
+
+        BooleanBuilder booleanBuilder = getBooleanBuilder(userId);
+        // 엔티티 조회
+        List<UserCoupon> userCoupons = queryFactory
+                .selectFrom(userCoupon)
+                .join(userCoupon.coupon, coupon).fetchJoin()
+                .where(booleanBuilder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // DTO로 변환
+        List<CouponReadMeResponse> results = userCoupons.stream()
+                .map(userCouponMapper::toCouponReadMeResponse)
+                .toList();
+
+        // 총 개수 계산
+        Long total = Objects.requireNonNullElse(
+                queryFactory
+                        .select(userCoupon.count())
+                        .from(userCoupon)
+                        .join(userCoupon.coupon, coupon)
+                        .where(booleanBuilder)
+                        .fetchOne(),
+                0L)
+                ;
+
+        return new PageImpl<>(results, pageable, total);
+
+    }
+
+    private BooleanBuilder getBooleanBuilder(String userId) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(userCoupon.userId.eq(userId));
+        builder.and(coupon.isDeleted.eq(false));
+        builder.and(userCoupon.isDeleted.eq(false));
+        return builder;
+    }
+}

--- a/coupon/src/main/java/com/haot/coupon/presentation/controller/CouponController.java
+++ b/coupon/src/main/java/com/haot/coupon/presentation/controller/CouponController.java
@@ -9,13 +9,11 @@ import com.haot.coupon.application.dto.feign.response.ReservationVerifyResponse;
 import com.haot.coupon.application.service.CouponService;
 import com.haot.coupon.common.response.ApiResponse;
 import com.haot.coupon.common.response.enums.SuccessCode;
-import com.haot.coupon.domain.model.enums.CouponStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -25,30 +23,12 @@ public class CouponController {
 
     private final CouponService couponService;
 
-    // TODO Header에서 userId 받아 사용
+    // TODO Header에서 userId 받아 사용 일단 request parama 사용
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/me")
-    public ApiResponse<List<CouponReadMeResponse>> getMyCoupons(String userId) {
-
-        List<CouponReadMeResponse> response = List.of(
-                CouponReadMeResponse.builder()
-                        .userCouponId("sdlkfsldknfsdaf")
-                        .couponName("테스트 쿠폰 1")
-                        .couponAvailableDate(LocalDateTime.now().minusDays(1))
-                        .couponExpiredDate(LocalDateTime.now().plusDays(1))
-                        .couponStatus(CouponStatus.DISTRIBUTED)
-                        .build()
-                ,
-                CouponReadMeResponse.builder()
-                        .userCouponId("sdlkfsldknsdfsdffsdaf")
-                        .couponName("테스트 쿠폰 2")
-                        .couponAvailableDate(LocalDateTime.now().minusDays(1))
-                        .couponExpiredDate(LocalDateTime.now().plusDays(1))
-                        .couponStatus(CouponStatus.UNUSED)
-                        .build()
-        );
-
-        return ApiResponse.success(response);
+    public ApiResponse<Page<CouponReadMeResponse>> getMyCoupons(@RequestHeader("X-User-Id") String userId,
+                                                                Pageable pageable) {
+        return ApiResponse.SUCCESS(SuccessCode.GET_USER_COUPONS_SUCCESS, couponService.getMyCoupons(userId, pageable));
     }
 
     @ResponseStatus(HttpStatus.OK)
@@ -83,7 +63,6 @@ public class CouponController {
                                                 @RequestBody FeignConfirmReservationRequest request) {
 
         couponService.confirmReservation(reservationCouponId, request);
-
         return ApiResponse.SUCCESS(SuccessCode.COUPON_RESERVATION_SUCCESS);
     }
 

--- a/coupon/src/main/java/com/haot/coupon/presentation/controller/CouponController.java
+++ b/coupon/src/main/java/com/haot/coupon/presentation/controller/CouponController.java
@@ -9,6 +9,8 @@ import com.haot.coupon.application.dto.feign.response.ReservationVerifyResponse;
 import com.haot.coupon.application.service.CouponService;
 import com.haot.coupon.common.response.ApiResponse;
 import com.haot.coupon.common.response.enums.SuccessCode;
+import com.haot.submodule.role.Role;
+import com.haot.submodule.role.RoleCheck;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,9 +25,9 @@ public class CouponController {
 
     private final CouponService couponService;
 
-    // TODO Header에서 userId 받아 사용 일단 request parama 사용
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/me")
+    @RoleCheck({Role.ADMIN, Role.USER})
     public ApiResponse<Page<CouponReadMeResponse>> getMyCoupons(@RequestHeader("X-User-Id") String userId,
                                                                 Pageable pageable) {
         return ApiResponse.SUCCESS(SuccessCode.GET_USER_COUPONS_SUCCESS, couponService.getMyCoupons(userId, pageable));


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #111 

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- pageable 기본 설정 resolver
- querydsl + mapstruct 적용
- order utils 클래스 적용

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공
![스크린샷 2025-01-10 120216](https://github.com/user-attachments/assets/ebb277c2-28f9-4990-bfdc-68bcbcad4cd8)
- 다중 정렬 요청
![스크린샷 2025-01-10 121007](https://github.com/user-attachments/assets/9f043a40-16b1-42a4-bd9e-fb2273d39144)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- order utils 시원님이 개발하신거 통해 재사용성 좋게 모든 조회 정렬은 orderUtils 클래스를 통해 이뤄지게 끔 개발
- querydsl + mapstruct 같이 적용(재사용성, 명확한 매핑 로직 분리)
- pageable 기본 설정인 pageable 객체 재생성도 재사용성 좋게 하나로 통일
- page가 음수일때는 0으로 변경
- size 10, 30, 50이 아니면 다 10으로 설정
- sort가 없으면 createdAt DESC 기본값
- 현재는 user가 자기 자신의 쿠폰 데이터만 볼 수 있게 해놨고 검색 X, pageable 객체로만 할 수 있는 것들만 된다.
- isDelete false 등등
- 추후에 admin이 들어와 조건을 걸어 데이터를 볼 수 있게끔 만들던가 따로 만들어야 될수도..
- 추후에 검색 조건들 추가할 수 있다.
