### PR TITLE
[Feat] Point: 포인트 적립 API 및 만료 구현

### DIFF
--- a/point/src/main/java/com/haot/point/PointApplication.java
+++ b/point/src/main/java/com/haot/point/PointApplication.java
@@ -2,8 +2,10 @@ package com.haot.point;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PointApplication {
 
 	public static void main(String[] args) {

--- a/point/src/main/java/com/haot/point/application/scheduler/PointExpirationScheduler.java
+++ b/point/src/main/java/com/haot/point/application/scheduler/PointExpirationScheduler.java
@@ -1,0 +1,26 @@
+package com.haot.point.application.scheduler;
+
+import com.haot.point.application.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class PointExpirationScheduler {
+
+    private final PointService pointService;
+
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정 실행
+    public void runDailyExpireBatch() {
+        LocalDateTime targetDate = LocalDateTime.now().minusDays(1); // 전날 기준
+        int page = 0;
+        int batchSize = 100;
+
+        while (pointService.expirePoints(targetDate, page, batchSize)) {
+            page++;
+        }
+    }
+}

--- a/point/src/main/java/com/haot/point/application/service/PointService.java
+++ b/point/src/main/java/com/haot/point/application/service/PointService.java
@@ -15,4 +15,7 @@ public interface PointService {
 
     // 포인트 사용
     PointAllResponse usePoint(PointTransactionRequest request, String pointId);
+
+    // 포인트 적립
+    PointAllResponse earnPoint(PointTransactionRequest request, String pointId);
 }

--- a/point/src/main/java/com/haot/point/application/service/PointService.java
+++ b/point/src/main/java/com/haot/point/application/service/PointService.java
@@ -5,6 +5,8 @@ import com.haot.point.application.dto.request.PointTransactionRequest;
 import com.haot.point.application.dto.response.PointAllResponse;
 import com.haot.point.application.dto.response.PointResponse;
 
+import java.time.LocalDateTime;
+
 public interface PointService {
 
     // 포인트 생성
@@ -18,4 +20,7 @@ public interface PointService {
 
     // 포인트 적립
     PointAllResponse earnPoint(PointTransactionRequest request, String pointId);
+
+    // 포인트 만료
+    boolean expirePoints(LocalDateTime targetDate, int page, int batchSize);
 }

--- a/point/src/main/java/com/haot/point/application/service/PointServiceImpl.java
+++ b/point/src/main/java/com/haot/point/application/service/PointServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Optional;
 
 @Slf4j(topic = "PointServiceImpl")
@@ -111,8 +112,8 @@ public class PointServiceImpl implements PointService{
 
         // 3. 만료 기간 설정
         // 적립 유형에 따른 포인트 적립 정책이 적용되면 추가 로직 필요
-        // 일단 모든 적립 포인트는 6개월 후 만료되도록 설정
-        LocalDateTime expiredAt = LocalDateTime.now().plusMonths(6);
+        // 일단 모든 적립 포인트는 6개월 뒤 자정에 만료되도록 설정
+        LocalDateTime expiredAt = LocalDateTime.now().plusMonths(6).with(LocalTime.MAX);
 
         // 3. PointHistory 생성
         PointHistory pointHistory = PointHistory.create(

--- a/point/src/main/java/com/haot/point/infrastructure/repository/PointHistoryRepository.java
+++ b/point/src/main/java/com/haot/point/infrastructure/repository/PointHistoryRepository.java
@@ -1,15 +1,37 @@
 package com.haot.point.infrastructure.repository;
 
 import com.haot.point.domain.model.PointHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PointHistoryRepository extends JpaRepository<PointHistory, String> {
-   @Query("SELECT ph FROM PointHistory ph WHERE ph.point.id = :pointId AND ph.status = 'PENDING'")
+    @Query("SELECT ph FROM PointHistory ph WHERE ph.point.id = :pointId AND ph.status = 'PENDING'")
     Optional<PointHistory> findPendingHistory(@Param("pointId") String pointId);
 
     Optional<PointHistory> findByIdAndIsDeletedFalse(String historyId);
+
+    // 만료 대상 적립 내역 조회
+    @Query("SELECT h FROM PointHistory h WHERE h.type = 'EARN' AND h.status = 'PROCESSED'" +
+            "AND h.expiredAt BETWEEN :startOfDay AND :endOfDay AND h.isDeleted = false")
+    Page<PointHistory> findExpiredPoints(
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay,
+            Pageable pageable
+    );
+
+    // 만료 대상 이후의 사용 포인트 조회
+    @Query("SELECT h FROM PointHistory h WHERE h.point.id = :pointId AND h.type = 'USE' AND h.status = 'PROCESSED'" +
+            "AND h.createdAt > :createdAt AND h.isDeleted = false ORDER BY h.createdAt ASC")
+    List<PointHistory> findUsedHistories(
+            @Param("pointId") String pointId,
+            @Param("createdAt") LocalDateTime createdAt
+    );
+
 }

--- a/point/src/main/java/com/haot/point/presentation/controller/PointController.java
+++ b/point/src/main/java/com/haot/point/presentation/controller/PointController.java
@@ -39,19 +39,7 @@ public class PointController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<PointAllResponse> earnPoint(@Valid @RequestBody PointTransactionRequest request,
                                                    @PathVariable String pointId) {
-        return ApiResponse.success(
-                new PointAllResponse(
-                        pointId,
-                        "HISTORY-UUID",
-                        "USER-UUID",
-                        request.points(),
-                        1000.0 + request.points(),
-                        "EARN",
-                        "RESERVATION-UUID EARN POINT",
-                        LocalDateTime.now().plusMonths(3),
-                        "ACTIVE"
-                )
-        );
+        return ApiResponse.success(pointService.earnPoint(request, pointId));
     }
 
     // 포인트 사용


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #116 
- 포인트 적립 및 만료 구현

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 포인트 적립 API 및 만료 구현
- 포인트 적립 시 만료 날짜 6개월 뒤 11:59으로 설정
- 포인트 만료는 매일 자정 스케줄러를 통해 만료 날짜가 하루 전인 포인트 만료 처리
  - 예를 들어, 1000 포인트 만료 날짜가 1/9 11:59 이고, 1/10일 자정에 스케줄러가 동작하여 만료 처리
  - 이 때, 1/19 일까지 적립된 1000 포인트에 대한 사용이 일어나지 않았을 경우에만 만료 처리
  - 500 포인트만 사용했다면, 남은 500 포인트에 대해 만료 처리

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 테스트를 위해 만료 날짜를 전날, 스케줄러를 10초마다 동작하도록 설정하여 확인했습니다.
- 적립
<img width="1111" alt="스크린샷 2025-01-10 오후 7 09 10" src="https://github.com/user-attachments/assets/2c8679b7-3764-4666-b9f3-3836883c7789" />
- 스케줄러 동작 전
<img width="1083" alt="스크린샷 2025-01-10 오후 7 09 18" src="https://github.com/user-attachments/assets/e5c79454-9051-4319-ab81-9d6a24ccb0ff" />
- 스케줄러 동작 후
<img width="1076" alt="스크린샷 2025-01-10 오후 7 09 24" src="https://github.com/user-attachments/assets/096d87cc-e620-4f55-a469-d58022a53cb2" />
- 만료 데이터 새로 생성</br>
<img width="311" alt="스크린샷 2025-01-10 오후 7 09 55" src="https://github.com/user-attachments/assets/9012d19f-6614-47c8-b6cd-cb0070aa6417" />

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 포인트 만료 처리를 어떻게 해야하나 고민했는데, 일단 포인트 만료 날짜 설정과 스케줄러을 이용하여 자정에 처리하도록 하는게 제일 빠른 구현이 될 것 같아서 적용했습니다.
- Redis 나 Kafka 를 이용하여 실시간 처리를 하는 방법도 있는 것 같은데 이건 트러블 슈팅 기간에 시간이 되면 찾아보겠습니다....!
- 추후에 시간이 된다면... 포인트 적립/만료 정책 등등 을 고려해서 추가하면 될 것 같습니다.
