### PR TITLE
[Feat] Reservation: 예약 수정 API 구현 #130

### DIFF
--- a/reservation/src/main/java/com/haot/reservation/application/service/ReservationService.java
+++ b/reservation/src/main/java/com/haot/reservation/application/service/ReservationService.java
@@ -2,6 +2,7 @@ package com.haot.reservation.application.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.haot.reservation.application.dtos.req.ReservationCreateRequest;
+import com.haot.reservation.application.dtos.req.ReservationUpdateRequest;
 import com.haot.reservation.application.dtos.res.ReservationGetResponse;
 import com.haot.submodule.role.Role;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,22 @@ public interface ReservationService {
    */
   ReservationGetResponse createReservation(
       ReservationCreateRequest request,
+      String userId,
+      Role role
+  ) throws JsonProcessingException;
+
+  /**
+   * 예약 수정 (결제 완료 or 취소)
+   * 결제 완료시 숙소, 쿠폰, 포인트의 상태를 변경합니다.
+   * @param reservationUpdateRequest paymentId, 예약 상태 COMPLETED or CANCELED
+   * @param reservationId 예약 아이디
+   * @param userId 유저 아이디
+   * @param role 권한
+   * @throws JsonProcessingException feignClient(상대방 서버의) 실패 응답
+   */
+  void updateReservation(
+      ReservationUpdateRequest reservationUpdateRequest,
+      String reservationId,
       String userId,
       Role role
   ) throws JsonProcessingException;

--- a/reservation/src/main/java/com/haot/reservation/infrastructure/dtos/payment/PaymentResponse.java
+++ b/reservation/src/main/java/com/haot/reservation/infrastructure/dtos/payment/PaymentResponse.java
@@ -1,0 +1,13 @@
+package com.haot.reservation.infrastructure.dtos.payment;
+
+public record PaymentResponse(
+    String paymentId,
+    String userId,
+    String reservationId,
+    String merchantId,
+    Double price,
+    Double finalPrice,
+    String method,
+    String status
+) {
+}

--- a/reservation/src/main/java/com/haot/reservation/presentation/controller/ReservationController.java
+++ b/reservation/src/main/java/com/haot/reservation/presentation/controller/ReservationController.java
@@ -15,9 +15,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,7 +39,8 @@ public class ReservationController {
       @RequestHeader(value = "X-User-Id", required = true) String userId,
       @RequestHeader(value = "X-User-Role", required = true) Role role
   ) throws JsonProcessingException {
-    return ApiResponse.success(reservationService.createReservation(reservationCreateRequest, userId, role));
+    return ApiResponse.success(
+        reservationService.createReservation(reservationCreateRequest, userId, role));
   }
 
   @ResponseStatus(HttpStatus.OK)
@@ -57,11 +58,14 @@ public class ReservationController {
   }
 
   @ResponseStatus(HttpStatus.OK)
-  @PatchMapping("/{reservationId}")
+  @PutMapping("/{reservationId}")
   public ApiResponse<Void> updateReservation(
       @RequestBody ReservationUpdateRequest reservationUpdateRequest,
-      @PathVariable String reservationId
-  ) {
+      @PathVariable String reservationId,
+      @RequestHeader(value = "X-User-Id", required = true) String userId,
+      @RequestHeader(value = "X-User-Role", required = true) Role role
+  ) throws JsonProcessingException {
+    reservationService.updateReservation(reservationUpdateRequest, reservationId, userId, role);
     return ApiResponse.success();
   }
 


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #130 
- 예약 수정(결제 성공 or 실패) API 구현
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- paymentId null 문제 해결
- 결제 성공 or 실패시 해당 api 호출
- status가 COMPLETED, CANCELED 에 따라 숙소, 쿠폰, 포인트의 상태를 변경합니다

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 응답
![image](https://github.com/user-attachments/assets/f4a6fb19-6b92-465c-b806-833e6b79e89a)
- 예약 성공시 포인트 상태 변경
![image](https://github.com/user-attachments/assets/ef298e4f-5c25-4bc4-827a-b3f3b297dfd2)
- 예약 성공 시 쿠폰 상태 변경
![스크린샷 2025-01-11 175125](https://github.com/user-attachments/assets/1a49291f-6cfc-4ce3-b88c-9209b16e59f0)
- 예약 성공 시 숙소 날짜 상태 변경
![image](https://github.com/user-attachments/assets/6f01f783-58bb-4b41-864e-73136fb706a4)
이 상황에서 update_by가 안들어가네요,,
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 테스트 이미지에서 숙소 상태변경에 update_by가 수정이 잘 안되는 것 같습니다
- 개선할 부분 궁금하신점 리뷰 부탁드립니다.
