### PR TITLE
[Fix] Reservation: 롤백 로직 #137

### DIFF
--- a/reservation/build.gradle
+++ b/reservation/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// aop
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 dependencyManagement {

--- a/reservation/src/main/java/com/haot/reservation/application/service/ReservationService.java
+++ b/reservation/src/main/java/com/haot/reservation/application/service/ReservationService.java
@@ -5,7 +5,6 @@ import com.haot.reservation.application.dtos.req.ReservationCreateRequest;
 import com.haot.reservation.application.dtos.req.ReservationUpdateRequest;
 import com.haot.reservation.application.dtos.res.ReservationGetResponse;
 import com.haot.submodule.role.Role;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface ReservationService {
 

--- a/reservation/src/main/java/com/haot/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation/src/main/java/com/haot/reservation/application/service/ReservationServiceImpl.java
@@ -70,6 +70,8 @@ public class ReservationServiceImpl implements ReservationService {
     String reservationCouponId = "";
     String paymentId = "";
     String pointHistoryId = "";
+    boolean couponApplied = false;
+    boolean pointApplied = false;
 
     // 예약 가능한 날짜 확인
     List<LodgeDateReadResponse> availableDates = getAvailableDates(
@@ -78,24 +80,50 @@ public class ReservationServiceImpl implements ReservationService {
         request.checkOutDate()
     );
 
-    // 숙소 적용 및 totalPrice 계산
+    // 숙소 상태 WAITING 및 totalPrice 계산
     LodgeDataGetResponse lodgeDataGetResponse = applyLodge(request, availableDates);
     totalPrice = lodgeDataGetResponse.totalPrice();
-
-    // 예약 상태 업데이트하는 List
     List<String> lodgeDateIds = lodgeDataGetResponse.lodgeDateIds();
 
-    // 쿠폰 적용 가격(totalPrice) 업데이트 및 reservationCouponId 반환
-    CouponDataResponse couponResponse = applyCoupon(userId, request.couponId(), totalPrice);
-    if (couponResponse != null) {
-      reservationCouponId = couponResponse.reservationCouponId();
-      totalPrice = couponResponse.totalPrice();
-    }
+    try {
+      // 쿠폰 적용 가격(totalPrice) 업데이트 및 reservationCouponId 반환
+      CouponDataResponse couponResponse = applyCoupon(userId, request.couponId(), totalPrice);
+      if (couponResponse != null) {
+        reservationCouponId = couponResponse.reservationCouponId();
+        totalPrice = couponResponse.totalPrice();
+        couponApplied = true;
+      }
 
-    // 포인트 적용 및 차감 가격(totalPrice) 업데이트
-    if (request.pointId() != null) {
-      pointHistoryId = applyPoint(request.pointId(), request.point(), userId, role);
-      totalPrice -= request.point();
+      // 포인트 적용 및 차감 가격(totalPrice) 업데이트
+      if (request.pointId() != null) {
+        pointHistoryId = applyPoint(request.pointId(), request.point(), userId, role);
+        totalPrice -= request.point();
+        pointApplied = true;
+      }
+
+    } catch (Exception e) {
+      // 롤백: 숙소 상태, 쿠폰 상태, 포인트 상태 되돌림
+      updateLodgeStatus(lodgeDateIds, "EMPTY");
+
+      if (couponApplied) {
+        // 쿠폰 롤백
+        log.info("Rolling back coupon. UserId: {}, Role: {}, ReservationCouponId: {}", userId, role,
+            reservationCouponId);
+        rollbackReservationCoupon(userId, role, reservationCouponId);
+      }
+      if (pointApplied) {
+        updatePointStatus(
+            new PointStatusRequest(
+                "롤백으로 인한 상태 변경 요청",
+                "ROLLBACK",
+                null
+            ),
+            pointHistoryId,
+            userId,
+            role
+        );
+      }
+      throw e; // Exception 재발생으로 트랜잭션 롤백
     }
 
     Reservation reservation = Reservation.createReservation(
@@ -189,7 +217,7 @@ public class ReservationServiceImpl implements ReservationService {
   private LodgeDataGetResponse applyLodge(
       ReservationCreateRequest request,
       List<LodgeDateReadResponse> dates
-  ) {
+  ) throws JsonProcessingException {
 
     Double totalPrice = 0.0;
     List<String> lodgeDateIds = new ArrayList<>();
@@ -206,6 +234,13 @@ public class ReservationServiceImpl implements ReservationService {
         throw new DateUnavailableException(ErrorCode.DATE_UNAVAILABLE_EXCEPTION);
       }
     }
+
+    try {
+      updateLodgeStatus(lodgeDateIds, "WAITING");
+    } catch (FeignException e) {
+      throw FeignExceptionUtils.parseFeignException(e);
+    }
+
     return LodgeDataGetResponse.of(lodgeDateIds, totalPrice);
   }
 
@@ -244,10 +279,11 @@ public class ReservationServiceImpl implements ReservationService {
       throws JsonProcessingException {
     try {
       return pointClient.usePoint(
-          new PointTransactionRequest(
-              usePoint,
-              "USE",
-              "포인트 사용"),
+              new PointTransactionRequest(
+                  usePoint,
+                  "USE",
+                  "포인트 사용"
+              ),
               pointId,
               userId,
               role
@@ -346,6 +382,15 @@ public class ReservationServiceImpl implements ReservationService {
     }
   }
 
+  private void rollbackReservationCoupon(String userId, Role role, String reservationCouponId)
+      throws JsonProcessingException {
+    try {
+      couponClient.rollbackReservationCoupon(userId, role, reservationCouponId);
+    } catch (FeignException e) {
+      throw FeignExceptionUtils.parseFeignException(e);
+    }
+  }
+
   // 결제 요청
   private PaymentDataResponse requestPayment(Reservation reservation, String userId, Role role)
       throws JsonProcessingException {
@@ -362,7 +407,8 @@ public class ReservationServiceImpl implements ReservationService {
       Map<String, Object> data = response.data();
       ObjectMapper objectMapper = new ObjectMapper();
 
-      PaymentResponse payment = objectMapper.convertValue(data.get("payment"), PaymentResponse.class);
+      PaymentResponse payment = objectMapper.convertValue(data.get("payment"),
+          PaymentResponse.class);
 
       String paymentId = payment.paymentId();
       String paymentUrl = (String) data.get("paymentPageUrl");
@@ -372,6 +418,7 @@ public class ReservationServiceImpl implements ReservationService {
       throw FeignExceptionUtils.parseFeignException(e);
     }
   }
+
   private Reservation findReservationById(String reservationId) {
     return reservationRepository.findById(reservationId)
         .orElseThrow(() -> new CustomReservationException(ErrorCode.RESERVATION_NOT_FOUND));

--- a/reservation/src/main/java/com/haot/reservation/infrastructure/client/CouponClient.java
+++ b/reservation/src/main/java/com/haot/reservation/infrastructure/client/CouponClient.java
@@ -26,7 +26,7 @@ public interface CouponClient {
   );
 
   //
-  @PutMapping("/{reservationCouponId}/rollback")
+  @PutMapping("/api/v1/coupons/{reservationCouponId}/rollback")
   ApiResponse<Void> rollbackReservationCoupon(
       @RequestHeader("X-User-Id") String userId,
       @RequestHeader("X-User-Role") Role role,

--- a/reservation/src/main/java/com/haot/reservation/infrastructure/client/CouponClient.java
+++ b/reservation/src/main/java/com/haot/reservation/infrastructure/client/CouponClient.java
@@ -4,11 +4,13 @@ import com.haot.reservation.common.response.ApiResponse;
 import com.haot.reservation.infrastructure.dtos.coupon.FeignConfirmReservationRequest;
 import com.haot.reservation.infrastructure.dtos.coupon.FeignVerifyRequest;
 import com.haot.reservation.infrastructure.dtos.coupon.ReservationVerifyResponse;
+import com.haot.submodule.role.Role;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient("coupon-service")
 public interface CouponClient {
@@ -20,5 +22,14 @@ public interface CouponClient {
   @PutMapping("/api/v1/coupons/{reservationCouponId}")
   ApiResponse<Void> confirmReservation(
       @PathVariable(value = "reservationCouponId") String reservationCouponId,
-      @RequestBody FeignConfirmReservationRequest request);
+      @RequestBody FeignConfirmReservationRequest request
+  );
+
+  //
+  @PutMapping("/{reservationCouponId}/rollback")
+  ApiResponse<Void> rollbackReservationCoupon(
+      @RequestHeader("X-User-Id") String userId,
+      @RequestHeader("X-User-Role") Role role,
+      @PathVariable(value = "reservationCouponId") String reservationCouponId
+  );
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #137  
- 예약 롤백 로직

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- gateway를 통한 예약 생성 정상 동작합니다. 
- 포인트나 쿠폰에서 에러 발생 시 숙소 상태 되돌리는 로직 추가
- rollbackReservationCoupon 메서드 추가
- 쿠폰 아이디를 잘못 입력할 경우 숙소 상태 되돌리도록 구현했습니다. 이 경우 point 로직을 타지 않기 때문에 포인트 사용, 롤백 로직은 동작하지 않습니다 즉, 숙소 상태는 롤백되고, 포인트는 사용되지 않기 때문에 롤백 로직 정상 동작
- 하지만 포인트 아이디를 잘못 입력한 경우 숙소 상태는 롤백이 되지만  rollbackReservationCoupon 메서드 즉 쿠폰 서버의 rollbackReservationCoupon 메서드가 동작하지 않아 생기는 문제입니다.
- 이유를 찾지 못해 혼자 문제 해결이 어려워 mvp 구현 이후에 해결하려고 합니다 (같이 테스트 하는 거 봐주세요,,) 
- 아래 Testing에 위 문제 이미지 첨부하겠습니다.

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- 코드
![스크린샷 2025-01-12 182348](https://github.com/user-attachments/assets/8f4b48d7-8c6b-4ee1-9a6e-7b264de17e5b)
- 디버그 rollbackReservationCoupon메서드에서 에러
![스크린샷 2025-01-12 182428](https://github.com/user-attachments/assets/d7489889-2321-4f34-a830-8c64b96371d2)
feign 메서드 호출시 필요한 데이터는 전부 가져오는데 catch에 잡히는 이유를 모르겠네요,,

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신점 개선할 점 리뷰 부탁드립니다.
