### PR TITLE
[Fix] Payment: 결제 확인 API 에 예약 서비스 호출 추가

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "auth/src/main/java/com/haot/submodule"]
 	path = auth/src/main/java/com/haot/submodule
 	url = https://github.com/How-about-over-there/submodule.git
+[submodule "src/main/java/com/haot/submodule"]
+	path = src/main/java/com/haot/submodule
+	url = https://github.com/How-about-over-there/submodule.git

--- a/payment/src/main/java/com/haot/payment/PaymentApplication.java
+++ b/payment/src/main/java/com/haot/payment/PaymentApplication.java
@@ -2,11 +2,13 @@ package com.haot.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication(scanBasePackages = {
 		"com.haot.payment",
 		"com.haot.submodule"
 })
+@EnableFeignClients
 public class PaymentApplication {
 
 	public static void main(String[] args) {

--- a/payment/src/main/java/com/haot/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/haot/payment/application/service/PaymentService.java
@@ -14,7 +14,7 @@ public interface PaymentService {
     PaymentResponse createPayment(PaymentCreateRequest request, String userId, Role role);
 
     // 결제 확인
-    PaymentResponse completePayment(String paymentId);
+    PaymentResponse completePayment(String paymentId, String userId, Role role);
 
     // 본인 결제 단건 조회
     PaymentResponse getPaymentById(String paymentId);

--- a/payment/src/main/java/com/haot/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/haot/payment/application/service/PaymentServiceImpl.java
@@ -10,7 +10,9 @@ import com.haot.payment.domain.enums.PaymentMethod;
 import com.haot.payment.domain.enums.PaymentStatus;
 import com.haot.payment.domain.model.Payment;
 import com.haot.payment.infrastructure.client.PortOneService;
+import com.haot.payment.infrastructure.client.ReservationClient;
 import com.haot.payment.infrastructure.client.dto.request.PortOneCancelRequest;
+import com.haot.payment.infrastructure.client.dto.request.ReservationUpdateRequest;
 import com.haot.payment.infrastructure.client.dto.response.PortOneCancelResponse;
 import com.haot.payment.infrastructure.client.dto.response.PortOneResponse;
 import com.haot.payment.infrastructure.repository.PaymentRepository;
@@ -29,6 +31,7 @@ public class PaymentServiceImpl implements PaymentService{
 
     private final PaymentRepository paymentRepository;
     private final PortOneService portOneService;
+    private final ReservationClient reservationClient;
 
     @Override
     @Transactional
@@ -55,7 +58,7 @@ public class PaymentServiceImpl implements PaymentService{
 
     @Override
     @Transactional
-    public PaymentResponse completePayment(String paymentId) {
+    public PaymentResponse completePayment(String paymentId, String userId, Role role) {
         // 1. 결제 데이터 확인
         Payment payment = validPayment(paymentId);
 
@@ -66,27 +69,38 @@ public class PaymentServiceImpl implements PaymentService{
         PaymentStatus status = PaymentStatus.fromString(paymentData.status());   // 결제 상태
         Double finalPrice = paymentData.amount().total().doubleValue(); // 결제 금액
 
-        // 3. 결제 상태 확인 및 데이터의 가격과 실제 지불된 금액을 비교
-        switch (status) {
-            case PAID:
-                if (!payment.getPrice().equals(finalPrice)) {   // 결제 금액 불일치 시 에러 발생
-                    log.error("결제 금액 불일치 ::::: 요청 금액 ::::: {} 최종 결제 금액 ::::: {}", payment.getPrice(), finalPrice);
-                    throw new CustomPaymentException(ErrorCode.PAYMENT_PRICE_MISMATCH);
-                }
-                log.info("결제 완료 ::::: {}", status);
-                break;
-            case CANCELLED:
-            case PARTIAL_CANCELLED:
-                throw new CustomPaymentException(ErrorCode.PAYMENT_ALREADY_PROCESSED);
-            default:
-                throw new CustomPaymentException(ErrorCode.INVALID_PAYMENT_STATUS);
+        // 3. 결제 상태 확인 및 데이터의 가격과 실제 지불된 금액을 비교 & 예약 상태 설정
+        String reservationStatus = "";
+        if (status == PaymentStatus.PAID) {
+            if (!payment.getPrice().equals(finalPrice)) {   // 결제 금액 불일치 시 에러 발생
+                log.error("결제 금액 불일치 ::::: 요청 금액 ::::: {} 최종 결제 금액 ::::: {}", payment.getPrice(), finalPrice);
+                throw new CustomPaymentException(ErrorCode.PAYMENT_PRICE_MISMATCH);
+            }
+            log.info("결제 완료 ::::: {}", status);
+            reservationStatus = "COMPLETED";// 결제 성공 시 예약 상태 COMPLETED 설정
+        } else {
+            log.info("결제가 취소된 상태 ::::: {}", status);
+            reservationStatus = "CANCELED"; // 결제 취소 시 예약 상태 CANCELED 설정
         }
 
         // 4. 결제 상태 변경
         payment.complete(paymentData.merchantId(), finalPrice, status);
 
-        // TODO: 5. 예약 상태 변경 API 호출
-
+        // 5. 예약 상태 변경 API 호출
+        ReservationUpdateRequest reservationUpdateRequest = new ReservationUpdateRequest(payment.getId(), reservationStatus);
+        log.info("결제 ID ::::: {}", reservationUpdateRequest.paymentId());
+        log.info("상태 ::::: {}", reservationUpdateRequest.status());
+        try {
+            reservationClient.updateReservation(
+                    reservationUpdateRequest,
+                    payment.getReservationId(),
+                    userId,
+                    role);
+            log.info("예약 상태 업데이트 완료 ::::: 예약 ID ::::: {} 상태 ::::: {}", payment.getReservationId(), reservationStatus);
+        }  catch (Exception e) {
+            log.error("예약 상태 업데이트 실패 ::::: 예약 ID ::::: {}", payment.getReservationId());
+            throw new CustomPaymentException(ErrorCode.RESERVATION_UPDATE_FAILED); // 예외 원인을 포함하여 다시 던지기
+        }
         return PaymentResponse.of(payment);
     }
 

--- a/payment/src/main/java/com/haot/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/haot/payment/application/service/PaymentServiceImpl.java
@@ -17,6 +17,7 @@ import com.haot.payment.infrastructure.client.dto.response.PortOneCancelResponse
 import com.haot.payment.infrastructure.client.dto.response.PortOneResponse;
 import com.haot.payment.infrastructure.repository.PaymentRepository;
 import com.haot.submodule.role.Role;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -97,9 +98,11 @@ public class PaymentServiceImpl implements PaymentService{
                     userId,
                     role);
             log.info("예약 상태 업데이트 완료 ::::: 예약 ID ::::: {} 상태 ::::: {}", payment.getReservationId(), reservationStatus);
-        }  catch (Exception e) {
-            log.error("예약 상태 업데이트 실패 ::::: 예약 ID ::::: {}", payment.getReservationId());
-            throw new CustomPaymentException(ErrorCode.RESERVATION_UPDATE_FAILED); // 예외 원인을 포함하여 다시 던지기
+        }  catch (FeignException e) {
+            log.error("예약 서비스 호출 실패 ::::: 상태 코드: {} 메시지: {}", e.status(), e.contentUTF8());
+            throw e; // 핸들러로 예외 전달
+        } catch (Exception e) {
+            throw new CustomPaymentException(ErrorCode.RESERVATION_UPDATE_FAILED);
         }
         return PaymentResponse.of(payment);
     }

--- a/payment/src/main/java/com/haot/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/haot/payment/application/service/PaymentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.haot.payment.application.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.haot.payment.application.dto.request.PaymentCancelRequest;
 import com.haot.payment.application.dto.request.PaymentCreateRequest;
 import com.haot.payment.application.dto.request.PaymentSearchRequest;
@@ -101,8 +102,8 @@ public class PaymentServiceImpl implements PaymentService{
         }  catch (FeignException e) {
             log.error("예약 서비스 호출 실패 ::::: 상태 코드: {} 메시지: {}", e.status(), e.contentUTF8());
             throw e; // 핸들러로 예외 전달
-        } catch (Exception e) {
-            throw new CustomPaymentException(ErrorCode.RESERVATION_UPDATE_FAILED);
+        } catch (JsonProcessingException e) {
+            throw new CustomPaymentException(ErrorCode.RESERVATION_UNAVAILABLE);
         }
         return PaymentResponse.of(payment);
     }

--- a/payment/src/main/java/com/haot/payment/common/exception/FeignClientException.java
+++ b/payment/src/main/java/com/haot/payment/common/exception/FeignClientException.java
@@ -1,0 +1,12 @@
+package com.haot.payment.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FeignClientException extends RuntimeException {
+  public String statusCode;
+  public String status;
+  public String message;
+}

--- a/payment/src/main/java/com/haot/payment/common/exception/enums/ErrorCode.java
+++ b/payment/src/main/java/com/haot/payment/common/exception/enums/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode implements ResCodeIfs {
     INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "8006", "결제가 완료되지 않았습니다."),
     PAYMENT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "8007", "이미 처리된 결제입니다."),
     USER_NOT_MATCHED(HttpStatus.BAD_REQUEST,"8008" , "유저 ID 가 일치하지 않습니다."),
-    RESERVATION_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "8009", "예약 서비스 호출에 실패하였습니다.");
+    RESERVATION_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "8009", "예약 서비스 호출에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/payment/src/main/java/com/haot/payment/common/exception/enums/ErrorCode.java
+++ b/payment/src/main/java/com/haot/payment/common/exception/enums/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode implements ResCodeIfs {
     PAYMENT_PRICE_MISMATCH(HttpStatus.BAD_REQUEST, "8005", "결제 요청 금액과 실제 결제 금액이 일치하지 않습니다."),
     INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "8006", "결제가 완료되지 않았습니다."),
     PAYMENT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "8007", "이미 처리된 결제입니다."),
-    USER_NOT_MATCHED(HttpStatus.BAD_REQUEST,"8008" , "유저 ID 가 일치하지 않습니다.");
+    USER_NOT_MATCHED(HttpStatus.BAD_REQUEST,"8008" , "유저 ID 가 일치하지 않습니다."),
+    RESERVATION_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "8009", "예약 서비스 호출에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/payment/src/main/java/com/haot/payment/common/exception/handler/FeignClientExceptionHandler.java
+++ b/payment/src/main/java/com/haot/payment/common/exception/handler/FeignClientExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.haot.payment.common.exception.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -17,6 +18,10 @@ public class FeignClientExceptionHandler {
 
         log.error("FeignException 발생 ::::: 상태 코드: {} 응답 바디: {}", e.status(), errorResponse);
 
+        // 응답 바디가 텍스트이거나 비어 있는 경우 JSON 응답 생성
+        if (errorResponse == null || !isJson(errorResponse)) {
+            errorResponse = "{\"message\":\"예약 서비스 호출에 실패하였습니다.\",\"status\":\"ERROR\",\"statusCode\":\"8009\"}";
+        }
         // Content-Type 을 application/json 으로 설정
         HttpHeaders headers = new HttpHeaders();
         headers.set("Content-Type", "application/json"); // JSON 요청 헤더 추가
@@ -26,5 +31,15 @@ public class FeignClientExceptionHandler {
                 .status(e.status()) // HTTP 상태 코드 그대로 사용
                 .headers(headers)   // Json 헤더 추가
                 .body(errorResponse); // 응답 바디 그대로 반환
+    }
+
+    private boolean isJson(String content) {
+        try {
+            final ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.readTree(content); // JSON 파싱 시도
+            return true; // JSON 형식이면 true 반환
+        } catch (Exception e) {
+            return false; // JSON 형식이 아니면 false 반환
+        }
     }
 }

--- a/payment/src/main/java/com/haot/payment/common/exception/handler/FeignClientExceptionHandler.java
+++ b/payment/src/main/java/com/haot/payment/common/exception/handler/FeignClientExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.haot.payment.common.exception.handler;
+
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class FeignClientExceptionHandler {
+
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<Object> handleFeignException(FeignException e) {
+        String errorResponse = e.contentUTF8(); // FeignException 에서 응답 바디 추출
+
+        log.error("FeignException 발생 ::::: 상태 코드: {} 응답 바디: {}", e.status(), errorResponse);
+
+        // Content-Type 을 application/json 으로 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json"); // JSON 요청 헤더 추가
+
+        // FeignException 의 상태 코드와 응답 바디를 그대로 클라이언트에 반환
+        return ResponseEntity
+                .status(e.status()) // HTTP 상태 코드 그대로 사용
+                .headers(headers)   // Json 헤더 추가
+                .body(errorResponse); // 응답 바디 그대로 반환
+    }
+}

--- a/payment/src/main/java/com/haot/payment/infrastructure/client/ReservationClient.java
+++ b/payment/src/main/java/com/haot/payment/infrastructure/client/ReservationClient.java
@@ -1,0 +1,22 @@
+package com.haot.payment.infrastructure.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.haot.payment.common.response.ApiResponse;
+import com.haot.payment.infrastructure.client.dto.request.ReservationUpdateRequest;
+import com.haot.submodule.role.Role;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@FeignClient(name = "reservation-service")
+public interface ReservationClient {
+
+    @ResponseStatus(HttpStatus.OK)
+    @PutMapping("/api/v1/reservations/{reservationId}")
+    ApiResponse<Void> updateReservation(
+            @RequestBody ReservationUpdateRequest reservationUpdateRequest,
+            @PathVariable String reservationId,
+            @RequestHeader(value = "X-User-Id", required = true) String userId,
+            @RequestHeader(value = "X-User-Role", required = true) Role role
+    ) throws JsonProcessingException;
+}

--- a/payment/src/main/java/com/haot/payment/infrastructure/client/dto/request/ReservationUpdateRequest.java
+++ b/payment/src/main/java/com/haot/payment/infrastructure/client/dto/request/ReservationUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.haot.payment.infrastructure.client.dto.request;
+
+public record ReservationUpdateRequest(
+    String paymentId,
+    String status
+
+) {
+
+}

--- a/payment/src/main/java/com/haot/payment/presentation/controller/PaymentController.java
+++ b/payment/src/main/java/com/haot/payment/presentation/controller/PaymentController.java
@@ -56,8 +56,10 @@ public class PaymentController {
     @PostMapping("/{paymentId}/complete")
     @ResponseStatus(HttpStatus.OK)
     @RoleCheck({Role.USER, Role.ADMIN})
-    public ApiResponse<PaymentResponse> completePayment(@PathVariable String paymentId) {
-        PaymentResponse payment = paymentService.completePayment(paymentId);
+    public ApiResponse<PaymentResponse> completePayment(@PathVariable String paymentId,
+                                                        @RequestHeader("X-User-Id") String userId,
+                                                        @RequestHeader("X-User-Role") Role role) {
+        PaymentResponse payment = paymentService.completePayment(paymentId, userId, role);
         log.info("결제 완료 정보: {}", ApiResponse.success(payment)); // 결제 확인 출력
         return ApiResponse.success(payment);
     }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #135 
- 결제 확인에 예약 상태 변경 호출 추가

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- ReservationClient 추가
- 예약에서 잡은 에러 그대로 내려주도록 구현
- 예약 서버가 켜져있지 않을 경우 JSON 응답을 생성해서 내려주도록 설정

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 예약 서비스 실행 X
<img width="1075" alt="스크린샷 2025-01-14 오전 10 40 09" src="https://github.com/user-attachments/assets/74bd6d65-895c-4da2-8faa-8d9ac34b9f63" />
- 예약 서비스 실행 O
<img width="1073" alt="스크린샷 2025-01-14 오전 9 40 19" src="https://github.com/user-attachments/assets/78a3896d-225a-4031-8c6c-6ec0843d6482" />

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 포트원 호출은 결제 확인 API 첫 구현 시 확인하였기에 예약 서비스 호출에 대해서만 테스트 진행했습니다.
- 예약 상태 변경에 값이 제대로 넘어가는 것은 우석님과 같이 확인하여 에러 상황에 대한 스크린샷만 추가하였습니다!