### PR TITLE
[Fix] Lodge: 날짜 상태 변경 요청 시의 동시성 문제 해결

### DIFF
--- a/lodge/build.gradle
+++ b/lodge/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 
 	runtimeOnly 'org.postgresql:postgresql'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
+
 	// querydsl
 	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeDateService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeDateService.java
@@ -26,7 +26,7 @@ public interface LodgeDateService {
             Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
     );
 
-    void updateStatus(LodgeDate lodgeDate, ReservationStatus requestStatus);
+    void updateStatusOf(List<String> lodgeDateIds, ReservationStatus newStatus);
 
     void deleteAllByLodge(Lodge lodge, String userId);
 

--- a/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeDateServiceImpl.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeDateServiceImpl.java
@@ -74,10 +74,11 @@ public class LodgeDateServiceImpl implements LodgeDateService {
     }
 
     @Override
-    public void updateStatus(
-            LodgeDate lodgeDate, ReservationStatus status
-    ) {
-        lodgeDate.updateStatus(status);
+    public void updateStatusOf(List<String> lodgeDateIds, ReservationStatus newStatus) {
+        lodgeDateIds.forEach(dateId -> {
+            LodgeDate lodgeDate = getValidLodgeDateById(dateId);
+            lodgeDate.updateStatus(newStatus);
+        });
     }
 
     @Override

--- a/lodge/src/main/java/com/haot/lodge/common/config/RedisConfig.java
+++ b/lodge/src/main/java/com/haot/lodge/common/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.haot.lodge.common.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    /**
+     * RedissonClient Bean 등록
+     */
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + redisHost + ":" + redisPort)
+                .setConnectionMinimumIdleSize(10)
+                .setConnectionPoolSize(50);
+
+        return Redisson.create(config);
+    }
+
+}
+

--- a/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
     DATE_RANGE_TOO_LONG(HttpStatus.BAD_REQUEST, "5104", "날짜 범위는 최대 365일을 초과할 수 없습니다."),
     START_DATE_TOO_FAR(HttpStatus.BAD_REQUEST, "5105", "시작 날짜는 현재 날짜로부터 1년 이내여야 합니다."),
     OVERLAPPING_DATES(HttpStatus.BAD_REQUEST, "5106", "해당 기간에 생성된 날짜가 이미 존재합니다."),
+    UNSELECTABLE_DATE(HttpStatus.CONFLICT, "5107", "예약 불가능한 날짜가 존재합니다."),
+    ALREADY_CHANGED_DATE_STATUS(HttpStatus.CONFLICT, "5107", "이미 해당 상태로 변경된 날짜입니다."),
 
     INVALID_DATE_STATUS(HttpStatus.BAD_REQUEST, "5105", "상태 타입이 유효하지 않습니다."),
     CANNOT_DELETE_SCHEDULED_DATE(HttpStatus.CONFLICT, "5106", "예약된 날짜는 삭제할 수 없습니다."),

--- a/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
+++ b/lodge/src/main/java/com/haot/lodge/common/exception/ErrorCode.java
@@ -33,7 +33,11 @@ public enum ErrorCode {
     // 5500: Service Common
     FORBIDDEN_ACCESS_LODGE(HttpStatus.FORBIDDEN,"5501", "해당 숙소의 관리자만 접근 가능합니다."),
     UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "5500", "지원하지 않는 정렬 방식입니다."),
-    FIlE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "5502", "이미지 업로드에 실패했습니다.");
+    FIlE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "5502", "이미지 업로드에 실패했습니다."),
+    // Redis Lock Error
+    REDIS_LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "5503", "현재 처리 중인 리소스가 있습니다. 잠시 후 다시 시도해주세요."),
+    REDIS_LOCK_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "5504", "Lock 획득 중 인터럽트가 발생했습니다."),
+    REDIS_LOCK_RELEASE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "5505", "Lock 해제 중 문제가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/lodge/src/main/java/com/haot/lodge/common/utils/RedisLockManager.java
+++ b/lodge/src/main/java/com/haot/lodge/common/utils/RedisLockManager.java
@@ -1,0 +1,61 @@
+package com.haot.lodge.common.utils;
+
+
+import com.haot.lodge.common.exception.ErrorCode;
+import com.haot.lodge.common.exception.LodgeException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisLockManager {
+
+    private final RedissonClient redissonClient;
+
+    /**
+     * Redis Lock 획득
+     * @param keys 락을 걸고자 하는 리소스의 식별자 리스트
+     * @param prefix 락 키에 사용할 접두사 (Redis 키 네이밍)
+     * @param waitTime 락을 획득하기 위해 대기할 최대 시간 (초)
+     * @param leaseTime 락이 유지될 시간 (초)
+     * @return 획득한 Redis 락 객체 목록
+     * @throws LodgeException  락을 획득하지 못하거나, 획득 중 인터럽트가 발생한 경우
+     */
+    public List<RLock> acquireLocks(List<String> keys, String prefix, long waitTime, long leaseTime) {
+        List<RLock> locks = new ArrayList<>();
+        for (String key : keys) {
+            RLock lock = redissonClient.getLock(prefix + key);
+            try {
+                if (!lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS)) {
+                    throw new LodgeException(ErrorCode.REDIS_LOCK_ACQUISITION_FAILED);
+                }
+                locks.add(lock);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new LodgeException(ErrorCode.REDIS_LOCK_INTERRUPTED);
+            }
+        }
+        return locks;
+    }
+
+    /**
+     * Redis Lock 해제
+     * @param locks 해제할 Redis 락 객체 목록
+     */
+    public void releaseLocks(List<RLock> locks) {
+        for (RLock lock : locks) {
+            if (lock.isHeldByCurrentThread()) {
+                try {
+                    lock.unlock();
+                } catch (IllegalStateException e) {
+                    throw new LodgeException(ErrorCode.REDIS_LOCK_RELEASE_FAILED);
+                }
+            }
+        }
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/domain/model/LodgeDate.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/model/LodgeDate.java
@@ -53,6 +53,9 @@ public class LodgeDate extends BaseEntity {
     }
 
     public void updateStatus(ReservationStatus status) {
+        if(this.status == status) {
+            throw new LodgeException(ErrorCode.ALREADY_CHANGED_DATE_STATUS);
+        }
         this.status = status;
     }
 

--- a/lodge/src/main/resources/application.yml
+++ b/lodge/src/main/resources/application.yml
@@ -15,6 +15,12 @@ spring:
          dialect: org.hibernate.dialect.PostgreSQLDialect
          format_sql: true
      show-sql: true
+  data:
+    redis:
+      host: localhost
+      port: 6389
+      username: default
+
 
 eureka:
   client:

--- a/lodge/src/test/java/com/haot/lodge/LodgeDateUpdateStatusTest.java
+++ b/lodge/src/test/java/com/haot/lodge/LodgeDateUpdateStatusTest.java
@@ -1,0 +1,103 @@
+package com.haot.lodge;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.haot.lodge.application.facade.LodgeDateFacade;
+import com.haot.lodge.application.service.LodgeDateService;
+import com.haot.lodge.common.exception.ErrorCode;
+import com.haot.lodge.common.exception.LodgeException;
+import com.haot.lodge.common.utils.RedisLockManager;
+import com.haot.lodge.domain.model.enums.ReservationStatus;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+
+@ExtendWith(MockitoExtension.class)
+public class LodgeDateUpdateStatusTest {
+
+    @Mock
+    private RedisLockManager redisLockManager;
+
+    @Mock
+    private LodgeDateService lodgeDateService;
+
+    @InjectMocks
+    private LodgeDateFacade lodgeDateFacade;
+
+
+    @Test
+    public void testUpdateStatus_SequentialProcessingWithError() throws InterruptedException {
+        // Given: Request
+        List<String> dateIds = List.of("UUID1", "UUID2", "UUID3");
+        String requestStatus = "WAITING";
+
+        // redisLockManager.acquireLocks 가 호출되었을 때 Mock 락 객체를 반환
+        RLock mockLock = mock(RLock.class);
+        when(redisLockManager
+                .acquireLocks(eq(dateIds), anyString(), anyLong(), anyLong()))
+                .thenReturn(List.of(mockLock));
+
+        // lodgeDateService.updateStatusOf 첫 번째 호출에서는 아무 동작도 하지 않고 (doNothing())
+        // 이후 호출에서 LodgeException 을 던지도록 정의 (doThrow)
+        doNothing()
+                .doThrow(new LodgeException(ErrorCode.ALREADY_CHANGED_DATE_STATUS))
+                .when(lodgeDateService)
+                .updateStatusOf(eq(dateIds), eq(ReservationStatus.WAITING));
+
+        // 성공과 실패 결과를 추적하기 위해 사용
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(5);
+        CountDownLatch latch = new CountDownLatch(5);
+
+        // When:
+        // ExecutorService 를 사용해 5개의 쓰레드가 동시에 lodgeDateFacade.updateStatus 를 호출
+        // 첫 번째 쓰레드는 정상적으로 상태를 변경하고, 이후 쓰레드는 이미 상태가 변경되었기 때문에 LodgeException 이 발생
+        for (int i = 0; i < 5; i++) {
+            executorService.submit(() -> {
+                try {
+                    lodgeDateFacade.updateStatus(dateIds, requestStatus);
+                    successCount.incrementAndGet();
+                } catch (LodgeException e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // 쓰레드 끝날때까지 기다리기
+        latch.await();
+
+        // Then: 결과 확인
+        assertEquals(1, successCount.get(), "하나의 쓰레드만 성공");
+        assertEquals(4, failureCount.get(), "다른 쓰레드는 요청 실패");
+
+        //redisLockManager.acquireLocks 와 releaseLocks 가 5번 호출되었는지 확인.
+        //lodgeDateService.updateStatusOf가 총 5번 호출되었는지 확인.
+        verify(redisLockManager, times(5)).acquireLocks(eq(dateIds), anyString(), anyLong(), anyLong());
+        verify(redisLockManager, times(5)).releaseLocks(anyList());
+        verify(lodgeDateService, times(5)).updateStatusOf(eq(dateIds), eq(ReservationStatus.WAITING));
+
+        executorService.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #147  

숙소 날짜 상태 변경 요청에서 발생할 수 있는 동시성 문제를 Redisson을 사용해 해결했습니다.
만약 같은 status 변경 요청이 들어오면 오류를 반환하도록 추가했습니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 관련 의존성 추가
- 관련 에러 코드 추가
- RedisLock 관리를 위한 유틸 클래스 추가
- LodgeDate의 updateStatus 메서드에 검증 추가
- 기존 상태 변경 메서드에서 Lock 사용하도록 변경
- facade에 있던 forEach 로직 service로 분리
## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 멀티 쓰레드 상황 테스트코드를 작성해 진행
![image](https://github.com/user-attachments/assets/4d9af300-785b-493e-be25-79ca03528f1c)

- 포스트맨을 통해 같은 요청을 보낼 경우의 오류 확인
![image](https://github.com/user-attachments/assets/d52ff09d-f090-48e0-896f-e5810615c5db)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- Jmeter도 사용해봐야 할 것 같은데 아직 해당 부분 습득이 안되어있어서 일단 테스트 코드만 작성했습니다
강의 마치고 꼭 실행해보고 개선 할 부분 개선하도록 하겠습니다!! 😭
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!