### PR TITLE
[Refactor] Lodge: 검색 파라미터를 객체로 받도록 변경

### DIFF
--- a/lodge/src/main/java/com/haot/lodge/application/dto/LodgeDateSearchCriteria.java
+++ b/lodge/src/main/java/com/haot/lodge/application/dto/LodgeDateSearchCriteria.java
@@ -1,0 +1,19 @@
+package com.haot.lodge.application.dto;
+
+import com.haot.lodge.domain.model.Lodge;
+import com.haot.lodge.presentation.request.LodgeDateSearchParams;
+import java.time.LocalDate;
+
+public record LodgeDateSearchCriteria(
+        Lodge lodge,
+        LocalDate start,
+        LocalDate end
+) {
+    public static LodgeDateSearchCriteria of(Lodge lodge, LodgeDateSearchParams params) {
+        return new LodgeDateSearchCriteria(
+                lodge,
+                params.start(),
+                params.end()
+        );
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/application/dto/LodgeSearchCriteria.java
+++ b/lodge/src/main/java/com/haot/lodge/application/dto/LodgeSearchCriteria.java
@@ -1,0 +1,26 @@
+package com.haot.lodge.application.dto;
+
+import com.haot.lodge.presentation.request.LodgeSearchParams;
+import java.time.LocalDate;
+
+public record LodgeSearchCriteria(
+        String hostId,
+        String name,
+        String address,
+        Integer maxReservationDay,
+        Integer maxPersonnel,
+        LocalDate checkInDate,
+        LocalDate checkOutDate
+) {
+    public static LodgeSearchCriteria of(LodgeSearchParams params, boolean onlyCheckIn) {
+        return new LodgeSearchCriteria(
+                params.hostId(),
+                params.name(),
+                params.address(),
+                params.maxReservationDay(),
+                params.maxPersonnel(),
+                params.checkInDate(),
+                (onlyCheckIn) ? params.checkInDate().plusDays(1) : null
+        );
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/application/facade/LodgeDateFacade.java
+++ b/lodge/src/main/java/com/haot/lodge/application/facade/LodgeDateFacade.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.application.facade;
 
 
+import com.haot.lodge.application.dto.LodgeDateSearchCriteria;
 import com.haot.lodge.application.service.LodgeDateService;
 import com.haot.lodge.application.service.LodgeService;
 import com.haot.lodge.common.exception.ErrorCode;
@@ -10,6 +11,7 @@ import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.model.LodgeDate;
 import com.haot.lodge.domain.model.enums.ReservationStatus;
 import com.haot.lodge.presentation.request.LodgeDateAddRequest;
+import com.haot.lodge.presentation.request.LodgeDateSearchParams;
 import com.haot.lodge.presentation.response.LodgeDateReadResponse;
 import com.haot.submodule.role.Role;
 import java.time.LocalDate;
@@ -44,11 +46,11 @@ public class LodgeDateFacade {
 
     @Transactional(readOnly = true)
     public Slice<LodgeDateReadResponse> readLodgeDates(
-            Pageable pageable, String lodgeId, LocalDate start, LocalDate end
+            Pageable pageable, LodgeDateSearchParams params
     ) {
-        Lodge lodge = lodgeService.getValidLodgeById(lodgeId);
+        Lodge lodge = lodgeService.getValidLodgeById(params.lodgeId());
         return lodgeDateService
-                .readAll(pageable, lodge, start, end)
+                .readAllBy(pageable, LodgeDateSearchCriteria.of(lodge, params))
                 .map(LodgeDateReadResponse::new);
     }
 

--- a/lodge/src/main/java/com/haot/lodge/application/facade/LodgeFacade.java
+++ b/lodge/src/main/java/com/haot/lodge/application/facade/LodgeFacade.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.application.facade;
 
 
+import com.haot.lodge.application.dto.LodgeSearchCriteria;
 import com.haot.lodge.application.response.LodgeImageResponse;
 import com.haot.lodge.application.response.LodgeResponse;
 import com.haot.lodge.application.response.LodgeRuleResponse;
@@ -11,11 +12,11 @@ import com.haot.lodge.application.service.LodgeService;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.model.LodgeRule;
 import com.haot.lodge.presentation.request.LodgeCreateRequest;
+import com.haot.lodge.presentation.request.LodgeSearchParams;
 import com.haot.lodge.presentation.request.LodgeUpdateRequest;
 import com.haot.lodge.presentation.response.LodgeReadAllResponse;
 import com.haot.lodge.presentation.response.LodgeReadOneResponse;
 import com.haot.submodule.role.Role;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -64,13 +65,10 @@ public class LodgeFacade {
 
     @Transactional(readOnly = true)
     public Slice<LodgeReadAllResponse> readAllLodgeBy(
-            Pageable pageable,
-            String hostId, String name, String address,
-            Integer maxReservationDay, Integer maxPersonnel,
-            LocalDate checkInDate, LocalDate checkOutDate
+            Pageable pageable, LodgeSearchParams params
     ) {
         return lodgeService
-                .readAllBy(pageable, hostId, name, address, maxReservationDay, maxPersonnel, checkInDate, checkOutDate)
+                .readAllBy(pageable, LodgeSearchCriteria.of(params, isOnlyCheckIn(params)))
                 .map(lodge -> new LodgeReadAllResponse(
                         LodgeResponse.from(lodge),
                         lodge.getImages()
@@ -78,6 +76,10 @@ public class LodgeFacade {
                                 .map(LodgeImageResponse::from)
                                 .toList()
                 ));
+    }
+
+    private boolean isOnlyCheckIn(LodgeSearchParams params) {
+        return (params.checkInDate()!= null && params.checkOutDate() == null);
     }
 
     @Transactional

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeDateService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeDateService.java
@@ -1,5 +1,6 @@
 package com.haot.lodge.application.service;
 
+import com.haot.lodge.application.dto.LodgeDateSearchCriteria;
 import com.haot.lodge.application.response.LodgeDateResponse;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.model.LodgeDate;
@@ -22,8 +23,8 @@ public interface LodgeDateService {
             List<LocalDate> excludeDates
     );
 
-    Slice<LodgeDateResponse> readAll(
-            Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
+    Slice<LodgeDateResponse> readAllBy(
+            Pageable pageable, LodgeDateSearchCriteria searchCriteria
     );
 
     void updateStatusOf(List<String> lodgeDateIds, ReservationStatus newStatus);

--- a/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/LodgeService.java
@@ -1,7 +1,7 @@
 package com.haot.lodge.application.service;
 
+import com.haot.lodge.application.dto.LodgeSearchCriteria;
 import com.haot.lodge.domain.model.Lodge;
-import java.time.LocalDate;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -23,13 +23,7 @@ public interface LodgeService {
 
     Slice<Lodge> readAllBy(
             Pageable pageable,
-            String hostId,
-            String name,
-            String address,
-            Integer maxReservationDay,
-            Integer maxPersonnel,
-            LocalDate checkInDate,
-            LocalDate checkOutDate
+            LodgeSearchCriteria searchCriteria
     );
 
     void update(

--- a/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeDateServiceImpl.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeDateServiceImpl.java
@@ -1,6 +1,7 @@
 package com.haot.lodge.application.service.implement;
 
 
+import com.haot.lodge.application.dto.LodgeDateSearchCriteria;
 import com.haot.lodge.application.response.LodgeDateResponse;
 import com.haot.lodge.application.service.LodgeDateService;
 import com.haot.lodge.common.exception.ErrorCode;
@@ -65,11 +66,11 @@ public class LodgeDateServiceImpl implements LodgeDateService {
     }
 
     @Override
-    public Slice<LodgeDateResponse> readAll(
-            Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
+    public Slice<LodgeDateResponse> readAllBy(
+            Pageable pageable, LodgeDateSearchCriteria searchCriteria
     ) {
         return lodgeDateRepository
-                .findAllLodgeDateByRange(pageable, lodge, start, end)
+                .findAllDateByConditionOf(pageable, searchCriteria)
                 .map(LodgeDateResponse::from);
     }
 

--- a/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeServiceImpl.java
+++ b/lodge/src/main/java/com/haot/lodge/application/service/implement/LodgeServiceImpl.java
@@ -1,12 +1,12 @@
 package com.haot.lodge.application.service.implement;
 
 
+import com.haot.lodge.application.dto.LodgeSearchCriteria;
 import com.haot.lodge.application.service.LodgeService;
 import com.haot.lodge.common.exception.ErrorCode;
 import com.haot.lodge.common.exception.LodgeException;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.repository.LodgeRepository;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -41,18 +41,9 @@ public class LodgeServiceImpl implements LodgeService {
 
     @Override
     public Slice<Lodge> readAllBy(
-            Pageable pageable,
-            String hostId, String name, String address,
-            Integer maxReservationDay, Integer maxPersonnel,
-            LocalDate checkInDate, LocalDate checkOutDate
+            Pageable pageable, LodgeSearchCriteria searchCriteria
     ) {
-        if(checkInDate!= null && checkOutDate == null){
-            checkOutDate = checkInDate.plusDays(1);
-        }
-        return lodgeRepository
-                .findAllByConditionOf(
-                        pageable, hostId, name, address, maxReservationDay, maxPersonnel, checkInDate, checkOutDate
-                );
+        return lodgeRepository.findAllByConditionOf(pageable, searchCriteria);
     }
 
     @Override

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeCustomRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeCustomRepository.java
@@ -1,7 +1,7 @@
 package com.haot.lodge.domain.repository;
 
+import com.haot.lodge.application.dto.LodgeSearchCriteria;
 import com.haot.lodge.domain.model.Lodge;
-import java.time.LocalDate;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -9,12 +9,6 @@ import org.springframework.data.domain.Slice;
 public interface LodgeCustomRepository {
     Slice<Lodge> findAllByConditionOf(
             Pageable pageable,
-            String hostId,
-            String name,
-            String address,
-            Integer maxReservationDay,
-            Integer maxPersonnel,
-            LocalDate checkInDate,
-            LocalDate checkOutDate
+            LodgeSearchCriteria searchCriteria
     );
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateCustomRepository.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/LodgeDateCustomRepository.java
@@ -1,5 +1,6 @@
 package com.haot.lodge.domain.repository;
 
+import com.haot.lodge.application.dto.LodgeDateSearchCriteria;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.model.LodgeDate;
 import java.time.LocalDate;
@@ -12,7 +13,7 @@ public interface LodgeDateCustomRepository {
             String lodgeId, LocalDate startDate, LocalDate endDate
     );
 
-    Slice<LodgeDate> findAllLodgeDateByRange(
-            Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
+    Slice<LodgeDate> findAllDateByConditionOf(
+            Pageable pageable, LodgeDateSearchCriteria searchCriteria
     );
 }

--- a/lodge/src/main/java/com/haot/lodge/domain/repository/impl/LodgeDateCustomRepositoryImpl.java
+++ b/lodge/src/main/java/com/haot/lodge/domain/repository/impl/LodgeDateCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.haot.lodge.domain.repository.impl;
 import static com.haot.lodge.domain.model.QLodgeDate.lodgeDate;
 import static com.haot.lodge.domain.utils.QuerydslSortUtils.getOrderSpecifiers;
 
+import com.haot.lodge.application.dto.LodgeDateSearchCriteria;
 import com.haot.lodge.domain.model.Lodge;
 import com.haot.lodge.domain.model.LodgeDate;
 import com.haot.lodge.domain.repository.LodgeDateCustomRepository;
@@ -46,10 +47,10 @@ public class LodgeDateCustomRepositoryImpl implements LodgeDateCustomRepository 
     }
 
     @Override
-    public Slice<LodgeDate> findAllLodgeDateByRange(
-            Pageable pageable, Lodge lodge, LocalDate start, LocalDate end
+    public Slice<LodgeDate> findAllDateByConditionOf(
+            Pageable pageable, LodgeDateSearchCriteria searchCriteria
     ) {
-        BooleanBuilder booleanBuilder = getBooleanBuilder(lodge, start, end);
+        BooleanBuilder booleanBuilder = getBooleanBuilder(searchCriteria);
         List<LodgeDate> result = queryFactory.selectFrom(lodgeDate)
                 .where(booleanBuilder)
                 .orderBy(getOrderSpecifiers(pageable, SORT_PARAMS))
@@ -63,12 +64,12 @@ public class LodgeDateCustomRepositoryImpl implements LodgeDateCustomRepository 
     }
 
     private BooleanBuilder getBooleanBuilder(
-            Lodge lodge, LocalDate start, LocalDate end
+            LodgeDateSearchCriteria searchCriteria
     ) {
         BooleanBuilder builder = new BooleanBuilder();
-        builder.and(eqLodge(lodge));
-        builder.and(afterStart(start));
-        builder.and(beforeEnd(end));
+        builder.and(eqLodge(searchCriteria.lodge()));
+        builder.and(afterStart(searchCriteria.start()));
+        builder.and(beforeEnd(searchCriteria.end()));
         builder.and(lodgeDate.isDeleted.eq(false));
         return builder;
     }

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
@@ -4,6 +4,7 @@ package com.haot.lodge.presentation.controller;
 import com.haot.lodge.application.response.LodgeResponse;
 import com.haot.lodge.application.facade.LodgeFacade;
 import com.haot.lodge.common.response.SliceResponse;
+import com.haot.lodge.presentation.request.LodgeSearchParams;
 import com.haot.lodge.presentation.response.LodgeReadAllResponse;
 import com.haot.lodge.presentation.request.LodgeCreateRequest;
 import com.haot.lodge.presentation.request.LodgeUpdateRequest;
@@ -13,7 +14,6 @@ import com.haot.lodge.presentation.response.LodgeReadOneResponse;
 import com.haot.submodule.role.Role;
 import com.haot.submodule.role.RoleCheck;
 import jakarta.validation.Valid;
-import java.time.LocalDate;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -23,13 +23,13 @@ import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -54,25 +54,16 @@ public class LodgeController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
     public ApiResponse<SliceResponse<LodgeReadAllResponse>> readAll(
-            @PageableDefault(size = 30)
+            @PageableDefault(size = 10)
             @SortDefault.SortDefaults({
                     @SortDefault(sort = "createdAt", direction = Direction.DESC),
                     @SortDefault(sort = "updatedAt", direction = Direction.DESC)
             })
             Pageable pageable,
-            @RequestParam(name = "hostId", required = false) String hostId,
-            @RequestParam(name = "name", required = false) String name,
-            @RequestParam(name = "address", required = false) String address,
-            @RequestParam(name = "maxReservationDay", required = false) Integer maxReservationDay,
-            @RequestParam(name = "maxPersonnel", required = false) Integer maxPersonnel,
-            @RequestParam(name = "checkInDate", required = false) LocalDate checkInDate,
-            @RequestParam(name = "checkOutDate", required = false) LocalDate checkOutDate
+            @ModelAttribute LodgeSearchParams searchParams
     ) {
         return ApiResponse.success(SliceResponse.of(
-                lodgeFacade.readAllLodgeBy(
-                        pageable,
-                        hostId, name, address, maxReservationDay, maxPersonnel, checkInDate, checkOutDate)
-        ));
+                lodgeFacade.readAllLodgeBy(pageable, searchParams)));
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeDateController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeDateController.java
@@ -5,13 +5,13 @@ import com.haot.lodge.application.facade.LodgeDateFacade;
 import com.haot.lodge.common.response.ApiResponse;
 import com.haot.lodge.common.response.SliceResponse;
 import com.haot.lodge.presentation.request.LodgeDateAddRequest;
+import com.haot.lodge.presentation.request.LodgeDateSearchParams;
 import com.haot.lodge.presentation.request.LodgeDateUpdateRequest;
 import com.haot.lodge.presentation.request.LodgeDateUpdateStatusRequest;
 import com.haot.lodge.presentation.response.LodgeDateReadResponse;
 import com.haot.submodule.role.Role;
 import com.haot.submodule.role.RoleCheck;
 import jakarta.validation.Valid;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
@@ -19,13 +19,13 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -50,17 +50,14 @@ public class LodgeDateController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
-    public ApiResponse<SliceResponse<LodgeDateReadResponse>> read(
+    public ApiResponse<SliceResponse<LodgeDateReadResponse>> readAll(
             @PageableDefault(size = 30)
             @SortDefault(sort = "date", direction = Direction.ASC)
             Pageable pageable,
-            @RequestParam(name = "lodgeId", required = true) String lodgeId,
-            @RequestParam(name = "start", required = false) LocalDate start,
-            @RequestParam(name = "end", required = false) LocalDate end
+            @Valid @ModelAttribute LodgeDateSearchParams searchParams
     ) {
         return ApiResponse.success(SliceResponse.of(
-                lodgeDateFacade.readLodgeDates(pageable, lodgeId, start, end)
-        ));
+                lodgeDateFacade.readLodgeDates(pageable, searchParams)));
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/lodge/src/main/java/com/haot/lodge/presentation/request/LodgeDateSearchParams.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/request/LodgeDateSearchParams.java
@@ -1,0 +1,11 @@
+package com.haot.lodge.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+public record LodgeDateSearchParams(
+        @NotBlank String lodgeId,
+        LocalDate start,
+        LocalDate end
+) {
+}

--- a/lodge/src/main/java/com/haot/lodge/presentation/request/LodgeSearchParams.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/request/LodgeSearchParams.java
@@ -1,0 +1,14 @@
+package com.haot.lodge.presentation.request;
+
+import java.time.LocalDate;
+
+public record LodgeSearchParams(
+        String hostId,
+        String name,
+        String address,
+        Integer maxReservationDay,
+        Integer maxPersonnel,
+        LocalDate checkInDate,
+        LocalDate checkOutDate
+) {
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #164  -> develop

기존의 컨트롤러에 하나씩 받았던 파라미터들을 객체로 분리하고 `@ModelAttribute` 를 이용해 받아오도록 변경했습니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 숙소, 숙소 날짜 검색 파라미터를 객체로 분리
- 서비스에서 사용할 dto 객체 생성
## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- 필요한 파라미터 입력되지 않았을 경우
![낫널](https://github.com/user-attachments/assets/ee7b55a8-ce18-4698-b486-19d4edab987f)

기존과 동일하게 잘 동작되는 것을 확인했습니다.
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 계층 역할을 명확하게 하기 위해 객체를 Params, Criteria 두 가지 형태로 나눴습니다.
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!