### PR TITLE
[Test] Lodge: 숙소와 숙소 날짜 api 성공 테스트 코드

### DIFF
--- a/lodge/build.gradle
+++ b/lodge/build.gradle
@@ -2,6 +2,8 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.7'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id "jacoco"
+	id "org.sonarqube" version "6.0.1.5171"
 }
 
 group = 'com.haot'
@@ -11,6 +13,10 @@ java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(17)
 	}
+}
+
+jacoco {
+	toolVersion = "0.8.8"
 }
 
 configurations {

--- a/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerCreatTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerCreatTest.java
@@ -1,0 +1,113 @@
+package com.haot.lodge.lodge.controller;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.haot.lodge.application.dto.LodgeDto;
+import com.haot.lodge.application.facade.LodgeFacade;
+import com.haot.lodge.application.response.LodgeCreateResponse;
+import com.haot.lodge.common.response.ApiResponse;
+import com.haot.lodge.presentation.controller.LodgeController;
+import com.haot.lodge.presentation.request.lodge.LodgeCreateRequest;
+import com.haot.submodule.role.Role;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+
+@WebMvcTest(LodgeController.class)
+@ExtendWith(MockitoExtension.class)
+public class LodgeControllerCreatTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LodgeFacade lodgeFacade;
+
+    @Test
+    @DisplayName("숙소 생성 성공 테스트")
+    void createLodge_Success() throws Exception {
+        // Given
+        String userId = "UserUUID";
+        Role role = Role.HOST;
+
+        LodgeCreateRequest request = new LodgeCreateRequest(
+                "해변가 숙소",
+                "아름다운 해변가 숙소입니다.",
+                "123 Ocean View Drive",
+                7,
+                250.00,
+                mock(MultipartFile.class),
+                "숙소 사진",
+                "밖에서 볼 수 있는 숙소 사진입니다.",
+                10,
+                5,
+                "애완 동물 출입 금지",
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31),
+                List.of(LocalDate.of(2025, 5, 1),
+                        LocalDate.of(2025, 12, 25)
+                )
+        );
+
+        LodgeDto lodgeDto = TestUtil.createMockLodgeDto();
+
+        ApiResponse<LodgeCreateResponse> expectedResponse = ApiResponse.success(new LodgeCreateResponse(lodgeDto));
+
+        // When
+        when(lodgeFacade
+                .createLodge(eq(userId), any(LodgeCreateRequest.class)))
+                .thenReturn(lodgeDto);
+
+        // Then
+        mockMvc.perform(multipart("/api/v1/lodges")
+                        .file("image", request.image().getBytes())
+                        .param("name", request.name())
+                        .param("description", request.description())
+                        .param("address", request.address())
+                        .param("term", String.valueOf(request.term()))
+                        .param("basicPrice", String.valueOf(request.basicPrice()))
+                        .param("imageTitle", request.imageTitle())
+                        .param("imageDescription", request.imageDescription())
+                        .param("maxReservationDay", String.valueOf(request.maxReservationDay()))
+                        .param("maxPersonnel", String.valueOf(request.maxPersonnel()))
+                        .param("customization", request.customization())
+                        .param("startDate", request.startDate().toString())
+                        .param("endDate", request.endDate().toString())
+                        .param("excludeDates", "2025-05-01", "2025-12-25")
+                        .header("X-User-Id", userId)
+                        .header("X-User-Role", role)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value("5000"))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("API 요청에 성공했습니다"))
+                .andExpect(jsonPath("$.data.lodge.id").value(lodgeDto.id()))
+                .andExpect(jsonPath("$.data.lodge.hostId").value(lodgeDto.hostId()))
+                .andExpect(jsonPath("$.data.lodge.name").value(lodgeDto.name()))
+                .andExpect(jsonPath("$.data.lodge.description").value(lodgeDto.description()))
+                .andExpect(jsonPath("$.data.lodge.address").value(lodgeDto.address()))
+                .andExpect(jsonPath("$.data.lodge.term").value(lodgeDto.term()))
+                .andExpect(jsonPath("$.data.lodge.basicPrice").value(lodgeDto.basicPrice()));
+
+        verify(lodgeFacade, times(1)).createLodge(eq(userId), any(LodgeCreateRequest.class));
+    }
+}

--- a/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerDeleteTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerDeleteTest.java
@@ -1,0 +1,58 @@
+package com.haot.lodge.lodge.controller;
+
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.haot.lodge.application.facade.LodgeFacade;
+import com.haot.lodge.presentation.controller.LodgeController;
+import com.haot.submodule.role.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LodgeController.class)
+@ExtendWith(MockitoExtension.class)
+public class LodgeControllerDeleteTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LodgeFacade lodgeFacade;
+
+    @Test
+    @DisplayName("숙소 삭제 성공 테스트")
+    void deleteLodge_Success() throws Exception {
+        // Given
+        String userId = "UserUUID";
+        Role userRole = Role.HOST;
+        String lodgeId = "LodgeUUID";
+
+        // When
+        doNothing().when(lodgeFacade).deleteLodge(userRole, userId, lodgeId);
+
+        // Then
+        mockMvc.perform(delete("/api/v1/lodges/{lodgeId}", lodgeId)
+                        .header("X-User-Id", userId)
+                        .header("X-User-Role", userRole.name())
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("5000"))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("API 요청에 성공했습니다"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(lodgeFacade, times(1)).deleteLodge(userRole, userId, lodgeId);
+    }
+
+}

--- a/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerReadAllTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerReadAllTest.java
@@ -1,0 +1,112 @@
+package com.haot.lodge.lodge.controller;
+
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.haot.lodge.application.dto.LodgeDto;
+import com.haot.lodge.application.dto.LodgeImageDto;
+import com.haot.lodge.application.facade.LodgeFacade;
+import com.haot.lodge.application.response.LodgeReadAllResponse;
+import com.haot.lodge.common.response.SliceResponse;
+import com.haot.lodge.presentation.controller.LodgeController;
+import com.haot.lodge.presentation.request.lodge.LodgeSearchParams;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LodgeController.class)
+@ExtendWith(MockitoExtension.class)
+public class LodgeControllerReadAllTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LodgeFacade lodgeFacade;
+
+    @Test
+    @DisplayName("숙소 목록 조회 성공 테스트")
+    void readAllLodges_Success() throws Exception {
+        // Given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(
+                Sort.Order.desc("createdAt"),
+                Sort.Order.desc("updatedAt")
+        ));
+
+        LodgeSearchParams searchParams = new LodgeSearchParams(
+                "UserUUID",
+                "해변가",
+                "Ocean",
+                10,
+                5,
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 1, 7)
+        );
+
+        LodgeDto lodgeDto = TestUtil.createMockLodgeDto();
+
+        LodgeImageDto imageDto = TestUtil.createMockLodgeImageDto();
+
+        LodgeReadAllResponse responseItem = new LodgeReadAllResponse(lodgeDto, List.of(imageDto));
+
+        Slice<LodgeReadAllResponse> mockSlice = new SliceImpl<>(
+                List.of(responseItem),
+                pageable,
+                false
+        );
+
+        SliceResponse<LodgeReadAllResponse> expectedResponse = SliceResponse.of(mockSlice);
+
+        // When
+        when(lodgeFacade.readAllLodgeBy(eq(pageable), eq(searchParams)))
+                .thenReturn(mockSlice);
+
+        // Then
+        mockMvc.perform(get("/api/v1/lodges")
+                        .param("hostId", searchParams.hostId())
+                        .param("name", searchParams.name())
+                        .param("address", searchParams.address())
+                        .param("maxReservationDay", String.valueOf(searchParams.maxReservationDay()))
+                        .param("maxPersonnel", String.valueOf(searchParams.maxPersonnel()))
+                        .param("checkInDate", searchParams.checkInDate().toString())
+                        .param("checkOutDate", searchParams.checkOutDate().toString())
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sort", "createdAt,DESC", "updatedAt,DESC")
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("5000"))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("API 요청에 성공했습니다"))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.sliceNumber").value(0))
+                .andExpect(jsonPath("$.data.numberOfElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].lodge.id").value(lodgeDto.id()))
+                .andExpect(jsonPath("$.data.content[0].lodge.hostId").value(lodgeDto.hostId()))
+                .andExpect(jsonPath("$.data.content[0].lodge.name").value(lodgeDto.name()))
+                .andExpect(jsonPath("$.data.content[0].images[0].id").value(imageDto.id()))
+                .andExpect(jsonPath("$.data.content[0].images[0].title").value(imageDto.title()));
+
+        verify(lodgeFacade, times(1)).readAllLodgeBy(eq(pageable), eq(searchParams));
+    }
+}

--- a/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerReadOneTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerReadOneTest.java
@@ -1,0 +1,82 @@
+package com.haot.lodge.lodge.controller;
+
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.haot.lodge.application.dto.LodgeDto;
+import com.haot.lodge.application.dto.LodgeImageDto;
+import com.haot.lodge.application.dto.LodgeRuleDto;
+import com.haot.lodge.application.facade.LodgeFacade;
+import com.haot.lodge.application.response.LodgeReadOneResponse;
+import com.haot.lodge.common.response.ApiResponse;
+import com.haot.lodge.presentation.controller.LodgeController;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LodgeController.class)
+@ExtendWith(MockitoExtension.class)
+public class LodgeControllerReadOneTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LodgeFacade lodgeFacade;
+
+
+    @Test
+    @DisplayName("숙소 단건 조회 성공 테스트")
+    void readOneLodge_Success() throws Exception {
+        // Given
+        String lodgeId = "LodgeUUID";
+
+        LodgeDto lodgeDto = TestUtil.createMockLodgeDto();
+        LodgeImageDto imageDto = TestUtil.createMockLodgeImageDto();
+        LodgeRuleDto ruleDto = TestUtil.createMockLodgeRuleDto();
+
+        LodgeReadOneResponse response = new LodgeReadOneResponse(
+                lodgeDto,
+                List.of(imageDto),
+                ruleDto
+        );
+
+        ApiResponse<LodgeReadOneResponse> expectedResponse = ApiResponse.success(response);
+
+        // When
+        when(lodgeFacade.readLodge(lodgeId)).thenReturn(response);
+
+        // Then
+        mockMvc.perform(get("/api/v1/lodges/{lodgeId}", lodgeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("5000"))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("API 요청에 성공했습니다"))
+                .andExpect(jsonPath("$.data.lodge.id").value(lodgeDto.id()))
+                .andExpect(jsonPath("$.data.lodge.hostId").value(lodgeDto.hostId()))
+                .andExpect(jsonPath("$.data.lodge.name").value(lodgeDto.name()))
+                .andExpect(jsonPath("$.data.lodge.description").value(lodgeDto.description()))
+                .andExpect(jsonPath("$.data.images[0].id").value(imageDto.id()))
+                .andExpect(jsonPath("$.data.images[0].title").value(imageDto.title()))
+                .andExpect(jsonPath("$.data.rule.id").value(ruleDto.id()))
+                .andExpect(jsonPath("$.data.rule.maxReservationDay").value(ruleDto.maxReservationDay()))
+                .andExpect(jsonPath("$.data.rule.maxPersonnel").value(ruleDto.maxPersonnel()))
+                .andExpect(jsonPath("$.data.rule.customization").value(ruleDto.customization()));
+
+        verify(lodgeFacade, times(1)).readLodge(lodgeId);
+    }
+}

--- a/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerUpdateTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodge/controller/LodgeControllerUpdateTest.java
@@ -1,0 +1,70 @@
+package com.haot.lodge.lodge.controller;
+
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haot.lodge.application.facade.LodgeFacade;
+import com.haot.lodge.presentation.controller.LodgeController;
+import com.haot.lodge.presentation.request.lodge.LodgeUpdateRequest;
+import com.haot.submodule.role.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LodgeController.class)
+@ExtendWith(MockitoExtension.class)
+public class LodgeControllerUpdateTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LodgeFacade lodgeFacade;
+
+    @Test
+    @DisplayName("숙소 수정 성공 테스트")
+    void updateLodge_Success() throws Exception {
+        // Given
+        String userId = "UserUUID";
+        Role userRole = Role.HOST;
+        String lodgeId = "LodgeUUID";
+
+        LodgeUpdateRequest updateRequest = new LodgeUpdateRequest(
+                "매우 좋은 해변가 숙소",
+                "업그레이드된 숙소입니다.",
+                "456 Ocean View Drive",
+                14,
+                300.00
+        );
+
+        // When
+        doNothing().when(lodgeFacade).updateLodge(userRole, userId, lodgeId, updateRequest);
+
+        // Then
+        mockMvc.perform(patch("/api/v1/lodges/{lodgeId}", lodgeId)
+                        .header("X-User-Id", userId)
+                        .header("X-User-Role", userRole)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(updateRequest))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("5000"))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("API 요청에 성공했습니다"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(lodgeFacade, times(1)).updateLodge(userRole, userId, lodgeId, updateRequest);
+    }
+}

--- a/lodge/src/test/java/com/haot/lodge/lodge/controller/TestUtil.java
+++ b/lodge/src/test/java/com/haot/lodge/lodge/controller/TestUtil.java
@@ -1,0 +1,37 @@
+package com.haot.lodge.lodge.controller;
+
+import com.haot.lodge.application.dto.LodgeDto;
+import com.haot.lodge.application.dto.LodgeImageDto;
+import com.haot.lodge.application.dto.LodgeRuleDto;
+
+public class TestUtil {
+    public static LodgeDto createMockLodgeDto() {
+        return LodgeDto.builder()
+                .id("LodgeUUID")
+                .hostId("UserUUID")
+                .name("해변가 숙소")
+                .description("아름다운 해변가 숙소입니다.")
+                .address("123 Ocean View Drive")
+                .term(7)
+                .basicPrice(250.00)
+                .build();
+    }
+
+    public static LodgeImageDto createMockLodgeImageDto() {
+        return LodgeImageDto.builder()
+                .id("ImageUUID")
+                .title("숙소 사진")
+                .description("밖에서 볼 수 있는 숙소 사진입니다.")
+                .url("https://example.com/image1.jpg")
+                .build();
+    }
+
+    public static LodgeRuleDto createMockLodgeRuleDto() {
+        return LodgeRuleDto.builder()
+                .id("RuleUUID")
+                .maxReservationDay(10)
+                .maxPersonnel(5)
+                .customization("애완견 출입 금지입니다.")
+                .build();
+    }
+}

--- a/lodge/src/test/java/com/haot/lodge/lodgedate/controller/LodgeDateControllerAddTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodgedate/controller/LodgeDateControllerAddTest.java
@@ -1,0 +1,78 @@
+package com.haot.lodge.lodgedate.controller;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haot.lodge.application.facade.LodgeDateFacade;
+import com.haot.lodge.presentation.controller.LodgeDateController;
+import com.haot.lodge.presentation.request.lodgedate.LodgeDateAddRequest;
+import com.haot.submodule.role.Role;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LodgeDateController.class)
+@ExtendWith(MockitoExtension.class)
+public class LodgeDateControllerAddTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LodgeDateFacade lodgeDateFacade;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("숙소 날짜 추가 성공 테스트")
+    void addLodgeDate_Success() throws Exception {
+        // Given
+        LodgeDateAddRequest request = new LodgeDateAddRequest(
+                "1",
+                LocalDate.of(2025, 1, 20),
+                LocalDate.of(2025, 1, 25),
+                List.of(LocalDate.of(2025, 1, 22))
+        );
+        Role role = Role.HOST;
+        String userId = "UserUUID";
+
+        // When
+        doNothing()
+                .when(lodgeDateFacade)
+                .addLodgeDate(role, userId, request);
+
+        // Then
+        mockMvc.perform(post("/api/v1/lodge-dates")
+                        .header("X-User-Id", userId)
+                        .header("X-User-Role", role)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value("5000"))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("API 요청에 성공했습니다"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(lodgeDateFacade, times(1))
+                .addLodgeDate(eq(role), eq(userId), eq(request));
+    }
+
+}

--- a/lodge/src/test/java/com/haot/lodge/lodgedate/controller/LodgeDateControllerReadAllTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodgedate/controller/LodgeDateControllerReadAllTest.java
@@ -1,0 +1,107 @@
+package com.haot.lodge.lodgedate.controller;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.haot.lodge.application.dto.LodgeDateDto;
+import com.haot.lodge.application.facade.LodgeDateFacade;
+import com.haot.lodge.application.response.LodgeDateReadResponse;
+import com.haot.lodge.common.response.SliceResponse;
+import com.haot.lodge.domain.model.enums.ReservationStatus;
+import com.haot.lodge.presentation.controller.LodgeDateController;
+import com.haot.lodge.presentation.request.lodgedate.LodgeDateSearchParams;
+import java.time.LocalDate;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LodgeDateController.class)
+@ExtendWith(MockitoExtension.class)
+public class LodgeDateControllerReadAllTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LodgeDateFacade lodgeDateFacade;
+
+    @Test
+    @DisplayName("숙소 날짜 목록 조회 성공 테스트")
+    void readAllLodgeDates_Success() throws Exception {
+        // Given
+        Pageable pageable = PageRequest.of(0, 30, Sort.by(Sort.Order.asc("date")));
+
+        LodgeDateSearchParams searchParams = new LodgeDateSearchParams(
+                "1",
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+        );
+
+        LodgeDateDto lodgeDateDto = new LodgeDateDto(
+                "1",
+                LocalDate.of(2025, 1, 20),
+                150.0,
+                ReservationStatus.WAITING
+        );
+
+        LodgeDateReadResponse responseItem = new LodgeDateReadResponse(lodgeDateDto);
+
+        Slice<LodgeDateReadResponse> mockSlice = new SliceImpl<>(
+                List.of(responseItem),
+                pageable,
+                false
+        );
+
+        SliceResponse<LodgeDateReadResponse> expectedResponse = SliceResponse.of(mockSlice);
+
+        // When
+        when(lodgeDateFacade.readLodgeDates(eq(pageable), eq(searchParams)))
+                .thenReturn(mockSlice);
+
+        // Then
+        mockMvc.perform(get("/api/v1/lodge-dates")
+                        .param("lodgeId", searchParams.lodgeId())
+                        .param("start", searchParams.start().toString())
+                        .param("end", searchParams.end().toString())
+                        .param("page", "0")
+                        .param("size", "30")
+                        .param("sort", "date,ASC")
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("5000"))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("API 요청에 성공했습니다"))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.sliceNumber").value(0))
+                .andExpect(jsonPath("$.data.numberOfElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].date.id").value(lodgeDateDto.id()))
+                .andExpect(jsonPath("$.data.content[0].date.date").value(lodgeDateDto.date().toString()))
+                .andExpect(jsonPath("$.data.content[0].date.price").value(lodgeDateDto.price()))
+                .andExpect(jsonPath("$.data.content[0].date.status").value(lodgeDateDto.status().toString()));
+
+        verify(lodgeDateFacade, times(1)).readLodgeDates(eq(pageable), eq(searchParams));
+    }
+
+}

--- a/lodge/src/test/java/com/haot/lodge/lodgedate/controller/LodgeDateControllerUpdateStatusTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodgedate/controller/LodgeDateControllerUpdateStatusTest.java
@@ -1,0 +1,67 @@
+package com.haot.lodge.lodgedate.controller;
+
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haot.lodge.application.facade.LodgeDateFacade;
+import com.haot.lodge.presentation.controller.LodgeDateController;
+import com.haot.lodge.presentation.request.lodgedate.LodgeDateUpdateStatusRequest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LodgeDateController.class)
+@ExtendWith(MockitoExtension.class)
+public class LodgeDateControllerUpdateStatusTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LodgeDateFacade lodgeDateFacade;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("숙소 날짜 상태 수정 성공 테스트")
+    void updateStatus_Success() throws Exception {
+        // Given
+        LodgeDateUpdateStatusRequest request = new LodgeDateUpdateStatusRequest(
+                List.of("1", "2", "3"), "WAITING"
+        );
+
+        // When
+        doNothing()
+                .when(lodgeDateFacade)
+                .updateStatus(eq(request.lodgeDateIds()), eq(request.status()));
+
+        // Then
+        mockMvc.perform(post("/api/v1/lodge-dates/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("5000"))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("API 요청에 성공했습니다"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(lodgeDateFacade, times(1))
+                .updateStatus(eq(request.lodgeDateIds()), eq(request.status()));
+    }
+}

--- a/lodge/src/test/java/com/haot/lodge/lodgedate/controller/LodgeDateControllerUpdateTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodgedate/controller/LodgeDateControllerUpdateTest.java
@@ -1,0 +1,68 @@
+package com.haot.lodge.lodgedate.controller;
+
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haot.lodge.application.facade.LodgeDateFacade;
+import com.haot.lodge.presentation.controller.LodgeDateController;
+import com.haot.lodge.presentation.request.lodgedate.LodgeDateUpdateRequest;
+import com.haot.submodule.role.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LodgeDateController.class)
+@ExtendWith(MockitoExtension.class)
+public class LodgeDateControllerUpdateTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LodgeDateFacade lodgeDateFacade;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("숙소 날짜 가격 수정 성공 테스트")
+    void updatePrice_Success() throws Exception {
+        // Given
+        LodgeDateUpdateRequest request = new LodgeDateUpdateRequest(12000.0);
+        Role role = Role.HOST;
+        String userId = "UserUUID";
+        String dateId = "DateUUID";
+
+        // When
+        doNothing().when(lodgeDateFacade).updatePrice(role, userId, dateId, request.price());
+
+        // Then
+        mockMvc.perform(patch("/api/v1/lodge-dates/{dateId}", dateId)
+                        .header("X-User-Id", userId)
+                        .header("X-User-Role", role)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("5000"))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("API 요청에 성공했습니다"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(lodgeDateFacade, times(1))
+                .updatePrice(eq(role), eq(userId), eq(dateId), eq(request.price()));
+    }
+}

--- a/lodge/src/test/java/com/haot/lodge/lodgedate/service/LodgeDateUpdateStatusTest.java
+++ b/lodge/src/test/java/com/haot/lodge/lodgedate/service/LodgeDateUpdateStatusTest.java
@@ -1,4 +1,4 @@
-package com.haot.lodge;
+package com.haot.lodge.lodgedate.service;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- 연관 #171  

숙소와 숙소 날짜 API의 성공 테스트 코드를 추가했습니다.
테스트 코드는 Mock 을 사용해 작성했습니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 테스트 코드 패키지 lodge/lodgedate 분리
- 기존 lodgeDateUpdateStatusTest를 lodgedate/service 패키지로 분리
## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 모든 테스트 케이스가 성공으로 작동함을 확인할 수 있습니다.
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 실패 케이스까지 전부 작성하려다 너무 늘어지는 것 같아서 일단 성공 먼저 올립니다! 
기존 코드 수정 작업 등, 해야 할 일 하면서 테스트 코드 더 작성하도록 하겠습니다.
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!