### PR TITLE
[Refactor] Pageable Resolver 추가

### DIFF
--- a/lodge/src/main/java/com/haot/lodge/infrastructure/config/QueryDslPageableConfig.java
+++ b/lodge/src/main/java/com/haot/lodge/infrastructure/config/QueryDslPageableConfig.java
@@ -1,0 +1,15 @@
+package com.haot.lodge.infrastructure.config;
+
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class QueryDslPageableConfig implements WebMvcConfigurer {
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new QueryDslPageableResolver());
+    }
+}

--- a/lodge/src/main/java/com/haot/lodge/infrastructure/config/QueryDslPageableResolver.java
+++ b/lodge/src/main/java/com/haot/lodge/infrastructure/config/QueryDslPageableResolver.java
@@ -1,0 +1,56 @@
+package com.haot.lodge.infrastructure.config;
+
+
+import java.util.function.Function;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class QueryDslPageableResolver extends PageableHandlerMethodArgumentResolver {
+
+    public static final Sort DEFAULT_SORT = Sort.by(Sort.Direction.DESC, "createdAt", "updatedAt");
+    public static final int MAXIMUM_SIZE = 50;
+
+    @Override
+    public @NotNull Pageable resolveArgument(
+            @NotNull MethodParameter methodParameter,
+            ModelAndViewContainer mavContainer,
+            @NotNull NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+        return validate(pageable, this::validatePageNumber, this::validatePageSize, this::validateSort);
+    }
+
+    private Pageable validate(
+            Pageable pageable,
+            Function<Integer, Integer> pageNumberValidator,
+            Function<Integer, Integer> pageSizeValidator,
+            Function<Sort, Sort> sortValidator
+    ) {
+        int pageNumber = pageNumberValidator.apply(pageable.getPageNumber());
+        int pageSize = pageSizeValidator.apply(pageable.getPageSize());
+        Sort sort = sortValidator.apply(pageable.getSort());
+
+        return PageRequest.of(pageNumber, pageSize, sort);
+    }
+
+    private Integer validatePageNumber(int pageNumber) {
+        return Math.max(pageNumber, 0);
+    }
+
+    private Integer validatePageSize(int pageSize) {
+        return Math.min(pageSize, MAXIMUM_SIZE);
+    }
+
+    private Sort validateSort(Sort sort) {
+        return sort.isSorted() ? sort : DEFAULT_SORT;
+    }
+
+}

--- a/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
+++ b/lodge/src/main/java/com/haot/lodge/presentation/controller/LodgeController.java
@@ -54,11 +54,6 @@ public class LodgeController implements LodgeControllerDocs{
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
     public ApiResponse<SliceResponse<LodgeReadAllResponse>> readAll(
-            @PageableDefault(size = 10)
-            @SortDefault.SortDefaults({
-                    @SortDefault(sort = "createdAt", direction = Direction.DESC),
-                    @SortDefault(sort = "updatedAt", direction = Direction.DESC)
-            })
             Pageable pageable,
             @ModelAttribute LodgeSearchParams searchParams
     ) {


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #181  

Pageable 을 커스터마이징 할 수 있는 Resolver를 추가했습니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 기본 Sort 기준을 생성 시간, 수정 시간 내림차순으로 설정
- size가 50이 넘을 경우 50으로 지정되도록 설정
## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 숙소 서비스의 목록 조회 API 호출 시, 정렬과 최대 사이즈 조절이 잘 이뤄지는 것을 확인할 수 있습니다.
![image](https://github.com/user-attachments/assets/fc21b4e3-fb1a-4716-9bdc-b3a23841f811)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- size 관련해서 저도 10, 30, 50 을 기본으로 할까 했는데 거의 Slice 방식으로 사용하니까 갯수는 조금 자유로워도 되지 않나 싶기도 하고 이런저런 생각을 하다가 그냥 최대값만 지정하고 넘으면 그냥 최대값으로 설정되도록 했습니다.
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!