### PR TITLE
[refactor] 이벤트 조회 Redis 캐시 적용

### DIFF
--- a/coupon/src/main/java/com/haot/coupon/application/dto/feign/request/FeignVerifyRequest.java
+++ b/coupon/src/main/java/com/haot/coupon/application/dto/feign/request/FeignVerifyRequest.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "[Feign] 쿠폰 유효성 검사 REQUEST DTO")
 public record FeignVerifyRequest(
         String couponId,
-        String userId,
         double reservationPrice
 ) {
 }

--- a/coupon/src/main/java/com/haot/coupon/application/dto/request/events/EventSearchRequest.java
+++ b/coupon/src/main/java/com/haot/coupon/application/dto/request/events/EventSearchRequest.java
@@ -38,7 +38,12 @@ public class EventSearchRequest {
     @Pattern(regexp = "DEFAULT|MANUALLY_CLOSED|EXPIRED|OUT_OF_STOCK", message = "유효한 상태 값을 입력하세요.")
     private String eventStatus;
 
-    public void setDelete(Boolean delete) {
-        this.isDelete = delete;
+    public boolean isAllFieldsNull() {
+        return nameKeyword == null &&
+                descriptionKeyword == null &&
+                startDate == null &&
+                endDate == null &&
+                isDelete == null &&
+                eventStatus == null;
     }
 }

--- a/coupon/src/main/java/com/haot/coupon/application/dto/response/PageResponse.java
+++ b/coupon/src/main/java/com/haot/coupon/application/dto/response/PageResponse.java
@@ -1,0 +1,20 @@
+package com.haot.coupon.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+
+@Schema(description = "Page Custom RESPONSE")
+@Builder
+public record PageResponse<T extends Serializable>(
+        int totalPages,
+        int pageNumber,
+        List<T> content
+) implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 673832261630062356L;
+}

--- a/coupon/src/main/java/com/haot/coupon/application/dto/response/events/EventSearchResponse.java
+++ b/coupon/src/main/java/com/haot/coupon/application/dto/response/events/EventSearchResponse.java
@@ -3,6 +3,8 @@ package com.haot.coupon.application.dto.response.events;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Schema(description = "이벤트 검색 RESPONSE DTO")
@@ -14,5 +16,9 @@ public record EventSearchResponse(
         LocalDateTime eventEndDate,
         String eventName,
         String eventDescription
-) {
+) implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = -5525036343673943620L;
+
 }

--- a/coupon/src/main/java/com/haot/coupon/application/mapper/CouponMapper.java
+++ b/coupon/src/main/java/com/haot/coupon/application/mapper/CouponMapper.java
@@ -21,7 +21,6 @@ public interface CouponMapper {
     @Mapping(source = "maxDiscountAmount", target = "maxAvailableAmount")
     @Mapping(source = "discountRate", target = "discountRate.rate")
     @Mapping(source = "discountAmount", target = "discountAmount")
-    @Mapping(ignore = true, target = "isDelete")
     @Mapping(ignore = true, target = "id")
     Coupon toEntity(CouponCreateRequest couponCreateRequest);
 

--- a/coupon/src/main/java/com/haot/coupon/application/mapper/EventMapper.java
+++ b/coupon/src/main/java/com/haot/coupon/application/mapper/EventMapper.java
@@ -20,7 +20,6 @@ public interface EventMapper {
     @Mapping(target = "coupon.id", source = "coupon.id")
     @Mapping(target = "description", source = "request.eventDescription")
     @Mapping(target = "eventStatus", constant = "DEFAULT")
-    @Mapping(target = "isDelete", ignore = true)
     CouponEvent toEntity(EventCreateRequest request, Coupon coupon);
 
     @Mapping(target = "eventId", source = "id")

--- a/coupon/src/main/java/com/haot/coupon/application/mapper/EventMapper.java
+++ b/coupon/src/main/java/com/haot/coupon/application/mapper/EventMapper.java
@@ -2,6 +2,7 @@ package com.haot.coupon.application.mapper;
 
 import com.haot.coupon.application.dto.EventClosedDto;
 import com.haot.coupon.application.dto.request.events.EventCreateRequest;
+import com.haot.coupon.application.dto.response.PageResponse;
 import com.haot.coupon.application.dto.response.events.EventCreateResponse;
 import com.haot.coupon.application.dto.response.events.EventSearchResponse;
 import com.haot.coupon.domain.model.Coupon;
@@ -9,6 +10,9 @@ import com.haot.coupon.domain.model.CouponEvent;
 import com.haot.coupon.domain.model.enums.EventStatus;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.springframework.data.domain.Page;
+
+import java.io.Serializable;
 
 @Mapper(componentModel = "spring")
 public interface EventMapper {
@@ -34,6 +38,13 @@ public interface EventMapper {
     @Mapping(source = "description", target = "eventDescription")
     EventSearchResponse toEventResponseDTO(CouponEvent event);
 
-
     EventClosedDto toProduce(String eventId, EventStatus status);
+
+    default <T extends Serializable> PageResponse<T> toPageResponse(Page<T> page) {
+        return new PageResponse<>(
+                page.getTotalPages(),
+                page.getNumber() + 1,
+                page.getContent()
+        );
+    }
 }

--- a/coupon/src/main/java/com/haot/coupon/application/mapper/ReservationCouponMapper.java
+++ b/coupon/src/main/java/com/haot/coupon/application/mapper/ReservationCouponMapper.java
@@ -13,7 +13,6 @@ public interface ReservationCouponMapper {
     @Mapping(target = "reservationPrice", source = "totalPrice")
     @Mapping(target = "reservationDiscountPrice", source = "discountPrice")
     @Mapping(target = "reservationCouponStatus", constant = "PREEMPTION")
-    @Mapping(target = "isDelete", ignore = true)
     ReservationCoupon toEntity(UserCoupon userCoupon, double totalPrice, double discountPrice);
 
     ReservationVerifyResponse toVerifyFeignResponse(String reservationCouponId, double discountedPrice);

--- a/coupon/src/main/java/com/haot/coupon/application/mapper/UserCouponMapper.java
+++ b/coupon/src/main/java/com/haot/coupon/application/mapper/UserCouponMapper.java
@@ -12,13 +12,11 @@ public interface UserCouponMapper {
     @Mapping(target = "coupon.id", source = "coupon.id")
     @Mapping(target = "couponStatus", constant = "DISTRIBUTED")
     @Mapping(target = "usedDate", ignore = true)
-    @Mapping(target = "isDelete", ignore = true)
     UserCoupon toEntity(String userId, Coupon coupon);
 
     @Mapping(target = "coupon.id", source = "couponId")
     @Mapping(target = "couponStatus", constant = "DISTRIBUTED")
     @Mapping(target = "usedDate", ignore = true)
-    @Mapping(target = "isDelete", ignore = true)
     UserCoupon toEntity(String userId, String couponId);
 
     // QueryDsl mapping

--- a/coupon/src/main/java/com/haot/coupon/application/service/CouponService.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/CouponService.java
@@ -22,7 +22,7 @@ public interface CouponService {
 
     CouponSearchResponse getCouponDetails(String couponId);
 
-    ReservationVerifyResponse verify(FeignVerifyRequest request);
+    ReservationVerifyResponse verify(String userId, FeignVerifyRequest request);
 
     void confirmReservation(String reservationCouponId, FeignConfirmReservationRequest request);
 

--- a/coupon/src/main/java/com/haot/coupon/application/service/EventService.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/EventService.java
@@ -1,13 +1,13 @@
 package com.haot.coupon.application.service;
 
 import com.haot.coupon.application.dto.request.events.EventSearchRequest;
+import com.haot.coupon.application.dto.response.PageResponse;
 import com.haot.coupon.application.dto.response.events.EventSearchResponse;
 import com.haot.submodule.role.Role;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface EventService {
     EventSearchResponse getEvent(String eventId);
 
-    Page<EventSearchResponse> searchEvent(Role userRole, EventSearchRequest request, Pageable pageable);
+    PageResponse<EventSearchResponse> searchEvent(Role userRole, EventSearchRequest request, Pageable pageable);
 }

--- a/coupon/src/main/java/com/haot/coupon/application/service/impl/AdminEventServiceImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/impl/AdminEventServiceImpl.java
@@ -16,6 +16,7 @@ import com.haot.coupon.domain.model.enums.EventStatus;
 import com.haot.coupon.infrastructure.repository.CouponEventRepository;
 import com.haot.coupon.infrastructure.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +38,7 @@ public class AdminEventServiceImpl implements AdminEventService {
     private final CouponErrorProducer couponErrorProducer;
 
     @Transactional
+    @CacheEvict(value = "eventPageCache", allEntries = true)
     @Override
     public EventCreateResponse create(EventCreateRequest eventCreateRequest) {
 
@@ -54,12 +56,12 @@ public class AdminEventServiceImpl implements AdminEventService {
 
 
         // 이벤트에 같은 선착순 쿠폰이 설정되면 안된다, 무제한은 가능하게!
-        if(CouponType.PRIORITY == coupon.getType() && couponEventRepository.existsByCouponIdAndIsDeletedFalse(coupon.getId())) {
+        if (CouponType.PRIORITY == coupon.getType() && couponEventRepository.existsByCouponIdAndIsDeletedFalse(coupon.getId())) {
             throw new CustomCouponException(ErrorCode.EXIST_PRIORITY_COUPON_EVENTS);
         }
 
         // 무제한은 이벤트들 안에서 여러번 같은 쿠폰을 쓸 수 있게 한다.
-        if(CouponType.UNLIMITED == coupon.getType()){
+        if (CouponType.UNLIMITED == coupon.getType()) {
 
             List<CouponEvent> promotions = couponEventRepository
                     .findByCouponIdAndEventEndDateIsAfterAndIsDeletedFalse(coupon.getId(), LocalDateTime.now())
@@ -81,7 +83,7 @@ public class AdminEventServiceImpl implements AdminEventService {
 
         CouponEvent savedEvent = couponEventRepository.save(event);
 
-        if(coupon.checkPriorityCoupon()){
+        if (coupon.checkPriorityCoupon()) {
             redisRepository.save(savedEvent, coupon);
         }
 
@@ -90,6 +92,8 @@ public class AdminEventServiceImpl implements AdminEventService {
 
     // 이벤트 수정 API, 문제가 생겼을때 확산 방지용 API or 이름, 설명 변경 API
     @Transactional
+    @CacheEvict(value = "eventPageCache", allEntries = true,
+            condition = "#request.eventStatus() != null")
     @Override
     public void modify(String userId, String eventId, EventModifyRequest request) {
 
@@ -99,7 +103,7 @@ public class AdminEventServiceImpl implements AdminEventService {
                 .orElseThrow(() -> new CustomCouponException(ErrorCode.EVENT_NOT_FOUND));
 
         // status 수정시 이벤트 관리자 강제 종료
-        if(request.eventStatus() != null) {
+        if (request.eventStatus() != null) {
 
             // 이미 끝난 이벤트는 status 수정 필요가 없게
             if (event.getEventStatus() != EventStatus.DEFAULT) {
@@ -107,22 +111,22 @@ public class AdminEventServiceImpl implements AdminEventService {
             }
 
             // 이벤트가 시작하기 전이면 상태값만 변경 -> 할당된 쿠폰은 쓰지 못하고 확인 후 delete 해야될듯
-            if(LocalDateTime.now().isBefore(event.getEventStartDate())){
+            if (LocalDateTime.now().isBefore(event.getEventStartDate())) {
                 event.updateEventStatus(EventStatus.MANUALLY_CLOSED);
-            }else{
+            } else {
                 Coupon coupon = event.getCoupon();
                 deleteCoupon(coupon, userId);
                 couponErrorProducer.sendEventClosed(eventMapper.toProduce(eventId, EventStatus.MANUALLY_CLOSED));
             }
 
-        }else{
+        } else {
             // 이름, description 수정
             event.modifyEvent(request.eventName(), request.eventDescription());
         }
     }
 
     // 쿠폰 삭제
-    private void deleteCoupon(Coupon coupon, String userId){
+    private void deleteCoupon(Coupon coupon, String userId) {
         coupon.deleteEntity(userId);
     }
 

--- a/coupon/src/main/java/com/haot/coupon/application/service/impl/AdminEventServiceImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/impl/AdminEventServiceImpl.java
@@ -48,13 +48,13 @@ public class AdminEventServiceImpl implements AdminEventService {
         }
 
         // event 끝 날짜가 쿠폰 만료 날짜보다 전이어야 된다.
-        Coupon coupon = couponRepository.findByIdAndExpiredDateIsAfterAndIsDeleteFalse(eventCreateRequest.couponId(),
+        Coupon coupon = couponRepository.findByIdAndExpiredDateIsAfterAndIsDeletedFalse(eventCreateRequest.couponId(),
                         eventCreateRequest.eventEndDate())
                 .orElseThrow(() -> new CustomCouponException(ErrorCode.COUPON_NOT_FOUND));
 
 
         // 이벤트에 같은 선착순 쿠폰이 설정되면 안된다, 무제한은 가능하게!
-        if(CouponType.PRIORITY == coupon.getType() && couponEventRepository.existsByCouponIdAndIsDeleteFalse(coupon.getId())) {
+        if(CouponType.PRIORITY == coupon.getType() && couponEventRepository.existsByCouponIdAndIsDeletedFalse(coupon.getId())) {
             throw new CustomCouponException(ErrorCode.EXIST_PRIORITY_COUPON_EVENTS);
         }
 
@@ -62,7 +62,7 @@ public class AdminEventServiceImpl implements AdminEventService {
         if(CouponType.UNLIMITED == coupon.getType()){
 
             List<CouponEvent> promotions = couponEventRepository
-                    .findByCouponIdAndEventEndDateIsAfterAndIsDeleteFalse(coupon.getId(), LocalDateTime.now())
+                    .findByCouponIdAndEventEndDateIsAfterAndIsDeletedFalse(coupon.getId(), LocalDateTime.now())
                     .stream()
                     .peek(couponEvent -> {
                         if (couponEvent.getEventStatus() == EventStatus.DEFAULT) {
@@ -95,7 +95,7 @@ public class AdminEventServiceImpl implements AdminEventService {
 
         validateNonEmptyFields(request.eventName(), request.eventDescription(), request.eventStatus());
 
-        CouponEvent event = couponEventRepository.findByIdAndIsDeleteFalse(eventId)
+        CouponEvent event = couponEventRepository.findByIdAndIsDeletedFalse(eventId)
                 .orElseThrow(() -> new CustomCouponException(ErrorCode.EVENT_NOT_FOUND));
 
         // status 수정시 이벤트 관리자 강제 종료

--- a/coupon/src/main/java/com/haot/coupon/application/service/impl/CouponServiceImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/impl/CouponServiceImpl.java
@@ -113,11 +113,11 @@ public class CouponServiceImpl implements CouponService {
     // 쿠폰 유효성 검사 API
     @Transactional
     @Override
-    public ReservationVerifyResponse verify(FeignVerifyRequest request) {
+    public ReservationVerifyResponse verify(String userId, FeignVerifyRequest request) {
 
         Coupon coupon = checkExistsCoupon(request.couponId());
 
-        UserCoupon userCoupon = findUserCoupon(request.userId(), coupon);
+        UserCoupon userCoupon = findUserCoupon(userId, coupon);
 
         // reservationCoupon 테이블 체크
         checkReservedCouponAvailable(userCoupon);

--- a/coupon/src/main/java/com/haot/coupon/application/service/impl/CouponServiceImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/impl/CouponServiceImpl.java
@@ -260,7 +260,7 @@ public class CouponServiceImpl implements CouponService {
     // user 쿠폰이 reservationCoupon 테이블에 CANCEL, ROLLBACK 상태가 아닌 다른 상태값이 DB에 있으면 사용불가
     private void checkReservedCouponAvailable(UserCoupon userCoupon) {
 
-        if (reservationCouponRepository.existsByUserCouponAndReservationCouponStatusNotInAndIsDeleteFalse(
+        if (reservationCouponRepository.existsByUserCouponAndReservationCouponStatusNotInAndIsDeletedFalse(
                 userCoupon, List.of(ReservationCouponStatus.ROLLBACK, ReservationCouponStatus.CANCEL))) {
             throw new CustomCouponException(ErrorCode.COUPON_UNAVAILABLE);
         }
@@ -268,7 +268,7 @@ public class CouponServiceImpl implements CouponService {
 
     // UserCoupon 조회 메소드
     private UserCoupon findUserCoupon(String userId, Coupon coupon) {
-        return userCouponRepository.findByUserIdAndCouponIdAndIsDeleteFalse(userId, coupon.getId())
+        return userCouponRepository.findByUserIdAndCouponIdAndIsDeletedFalse(userId, coupon.getId())
                 .orElseThrow(() -> new CustomCouponException(ErrorCode.USER_COUPON_NOT_FOUND));
     }
 
@@ -374,7 +374,7 @@ public class CouponServiceImpl implements CouponService {
     // 쿠폰 DB check
     private Coupon checkExistsCoupon(String couponId) {
 
-        return couponRepository.findByIdAndIsDeleteFalse(couponId)
+        return couponRepository.findByIdAndIsDeletedFalse(couponId)
                 .orElseThrow(() -> new CustomCouponException(ErrorCode.COUPON_NOT_FOUND));
     }
 

--- a/coupon/src/main/java/com/haot/coupon/application/service/impl/EventServiceImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/impl/EventServiceImpl.java
@@ -11,6 +11,7 @@ import com.haot.coupon.domain.model.CouponEvent;
 import com.haot.coupon.infrastructure.repository.CouponEventRepository;
 import com.haot.submodule.role.Role;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,20 +38,17 @@ public class EventServiceImpl implements EventService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "eventPageCache",
+            key = "T(String).format('%s:%s', #pageable.pageNumber, #pageable.pageSize)",
+            condition = "#request != null && #request.isAllFieldsNull()")
     @Override
     public PageResponse<EventSearchResponse> searchEvent(Role userRole, EventSearchRequest request, Pageable pageable) {
 
         if(userRole == Role.USER){
-
-            // 사용자일때 삭제된 이벤트 보여주지 않는다.
-            if(request.getIsDelete() == null || request.getIsDelete()){
-                request.setDelete(false);
-            }
-
             validateIfUserNonNullFields(request.getStartDate(), request.getEndDate(), request.getEventStatus());
         }
 
-        return eventMapper.toPageResponse(couponEventRepository.searchEventByRole(request, pageable));
+        return eventMapper.toPageResponse(couponEventRepository.searchEventByRole(userRole, request, pageable));
     }
 
     private void validateIfUserNonNullFields(LocalDateTime startDate, LocalDateTime endDate, String eventStatus) {

--- a/coupon/src/main/java/com/haot/coupon/application/service/impl/EventServiceImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/application/service/impl/EventServiceImpl.java
@@ -1,6 +1,7 @@
 package com.haot.coupon.application.service.impl;
 
 import com.haot.coupon.application.dto.request.events.EventSearchRequest;
+import com.haot.coupon.application.dto.response.PageResponse;
 import com.haot.coupon.application.dto.response.events.EventSearchResponse;
 import com.haot.coupon.application.mapper.EventMapper;
 import com.haot.coupon.application.service.EventService;
@@ -10,7 +11,6 @@ import com.haot.coupon.domain.model.CouponEvent;
 import com.haot.coupon.infrastructure.repository.CouponEventRepository;
 import com.haot.submodule.role.Role;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +38,7 @@ public class EventServiceImpl implements EventService {
 
     @Transactional(readOnly = true)
     @Override
-    public Page<EventSearchResponse> searchEvent(Role userRole, EventSearchRequest request, Pageable pageable) {
+    public PageResponse<EventSearchResponse> searchEvent(Role userRole, EventSearchRequest request, Pageable pageable) {
 
         if(userRole == Role.USER){
 
@@ -50,7 +50,7 @@ public class EventServiceImpl implements EventService {
             validateIfUserNonNullFields(request.getStartDate(), request.getEndDate(), request.getEventStatus());
         }
 
-        return couponEventRepository.searchEventByRole(request, pageable);
+        return eventMapper.toPageResponse(couponEventRepository.searchEventByRole(request, pageable));
     }
 
     private void validateIfUserNonNullFields(LocalDateTime startDate, LocalDateTime endDate, String eventStatus) {

--- a/coupon/src/main/java/com/haot/coupon/domain/model/Coupon.java
+++ b/coupon/src/main/java/com/haot/coupon/domain/model/Coupon.java
@@ -56,9 +56,6 @@ public class Coupon extends BaseEntity {
     @Column(nullable = true, name = "discount_amount")
     private Double discountAmount;
 
-    @Column(name = "is_delete", nullable = false)
-    private boolean isDelete;
-
     public void issue(){
         this.issuedQuantity++;
     }

--- a/coupon/src/main/java/com/haot/coupon/domain/model/CouponEvent.java
+++ b/coupon/src/main/java/com/haot/coupon/domain/model/CouponEvent.java
@@ -42,10 +42,6 @@ public class CouponEvent extends BaseEntity {
     @Column(nullable = false)
     private EventStatus eventStatus;
 
-    @Column(name = "is_delete", nullable = false)
-    private boolean isDelete;
-
-
     public void updateExpiredEventStatus(){
 
         LocalDateTime now = LocalDateTime.now();

--- a/coupon/src/main/java/com/haot/coupon/domain/model/ReservationCoupon.java
+++ b/coupon/src/main/java/com/haot/coupon/domain/model/ReservationCoupon.java
@@ -31,10 +31,6 @@ public class ReservationCoupon extends BaseEntity {
     @Column(nullable = false, name = "reservation_discount_price")
     private Double reservationDiscountPrice;
 
-    @Column(name = "is_delete", nullable = false)
-    private boolean isDelete;
-
-
     public void confirmReservationStatus(ReservationCouponStatus status) {
         this.reservationCouponStatus = status;
     }

--- a/coupon/src/main/java/com/haot/coupon/domain/model/UserCoupon.java
+++ b/coupon/src/main/java/com/haot/coupon/domain/model/UserCoupon.java
@@ -33,8 +33,6 @@ public class UserCoupon extends BaseEntity {
     @Column(nullable = true, name = "used_date")
     private LocalDateTime usedDate;
 
-    @Column(name = "is_delete", nullable = false)
-    private boolean isDelete;
 
     public void reservationComplete() {
         this.couponStatus = CouponStatus.USED;

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/config/CacheConfig.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/config/CacheConfig.java
@@ -1,0 +1,54 @@
+package com.haot.coupon.infrastructure.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.haot.coupon.application.dto.response.PageResponse;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .findAndRegisterModules()
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .registerModule(new JavaTimeModule());
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
+
+        RedisCacheConfiguration pageConfig = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofMinutes(20))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new Jackson2JsonRedisSerializer<>(objectMapper, PageResponse.class))
+                );
+
+        return RedisCacheManager
+                .builder(redisConnectionFactory)
+                .withCacheConfiguration("eventPageCache", pageConfig)
+                .build();
+    }
+
+
+}

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/CouponEventCustomRepository.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/CouponEventCustomRepository.java
@@ -2,9 +2,10 @@ package com.haot.coupon.infrastructure.repository;
 
 import com.haot.coupon.application.dto.request.events.EventSearchRequest;
 import com.haot.coupon.application.dto.response.events.EventSearchResponse;
+import com.haot.submodule.role.Role;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CouponEventCustomRepository {
-    Page<EventSearchResponse> searchEventByRole(EventSearchRequest request, Pageable pageable);
+    Page<EventSearchResponse> searchEventByRole(Role userRole, EventSearchRequest request, Pageable pageable);
 }

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/CouponEventRepository.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/CouponEventRepository.java
@@ -25,7 +25,7 @@ public interface CouponEventRepository extends JpaRepository<CouponEvent, String
     Optional<CouponEvent> findByIdAndEventStatusAndIsDeleteFalse(@Param("eventId") String eventId,
                                                                  @Param("eventStatus") EventStatus eventStatus);
 
-    Optional<CouponEvent> findByIdAndIsDeleteFalse(String eventId);
+    Optional<CouponEvent> findByIdAndIsDeletedFalse(String eventId);
 
     @Query("SELECT new com.haot.coupon.application.dto.CheckAlreadyClosedEventDto(e.id, e.coupon.id) " +
             "FROM CouponEvent e " +

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/CouponEventRepository.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/CouponEventRepository.java
@@ -15,13 +15,13 @@ import java.util.Set;
 
 public interface CouponEventRepository extends JpaRepository<CouponEvent, String>, CouponEventCustomRepository {
 
-    boolean existsByCouponIdAndIsDeleteFalse(String CouponId);
+    boolean existsByCouponIdAndIsDeletedFalse(String CouponId);
 
-    List<CouponEvent> findByCouponIdAndEventEndDateIsAfterAndIsDeleteFalse(String id, LocalDateTime now);
+    List<CouponEvent> findByCouponIdAndEventEndDateIsAfterAndIsDeletedFalse(String id, LocalDateTime now);
 
     @Query("SELECT ce FROM CouponEvent ce JOIN FETCH ce.coupon c " +
             "WHERE ce.id = :eventId AND ce.eventStatus = :eventStatus " +
-            "AND ce.isDelete = false AND c.isDelete = false")
+            "AND ce.isDeleted = false AND c.isDeleted = false")
     Optional<CouponEvent> findByIdAndEventStatusAndIsDeleteFalse(@Param("eventId") String eventId,
                                                                  @Param("eventStatus") EventStatus eventStatus);
 

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/CouponRepository.java
@@ -13,9 +13,9 @@ import java.util.Set;
 
 public interface CouponRepository extends JpaRepository<Coupon, String> {
 
-    Optional<Coupon> findByIdAndExpiredDateIsAfterAndIsDeleteFalse(String couponId, LocalDateTime eventEndDate);
+    Optional<Coupon> findByIdAndExpiredDateIsAfterAndIsDeletedFalse(String couponId, LocalDateTime eventEndDate);
 
-    Optional<Coupon> findByIdAndIsDeleteFalse(String couponId);
+    Optional<Coupon> findByIdAndIsDeletedFalse(String couponId);
 
     @Modifying
     @Query(value = "update coupon.p_coupon SET issued_quantity = issued_quantity + :issuedCount WHERE id = :id", nativeQuery = true)

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/ReservationCouponRepository.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/ReservationCouponRepository.java
@@ -6,9 +6,8 @@ import com.haot.coupon.domain.model.enums.ReservationCouponStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ReservationCouponRepository extends JpaRepository<ReservationCoupon, String> {
-    boolean existsByUserCouponAndReservationCouponStatusNotInAndIsDeleteFalse(
+    boolean existsByUserCouponAndReservationCouponStatusNotInAndIsDeletedFalse(
             UserCoupon userCoupon, List<ReservationCouponStatus> excludedStatuses);
 }

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/UserCouponRepository.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/UserCouponRepository.java
@@ -6,7 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, String>, UserCouponCustomRepository {
-    boolean existsByUserIdAndCouponIdAndIsDeleteFalse(String userId, String couponId);
-
-    Optional<UserCoupon> findByUserIdAndCouponIdAndIsDeleteFalse(String userId, String couponId);
+    Optional<UserCoupon> findByUserIdAndCouponIdAndIsDeletedFalse(String userId, String couponId);
 }

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/impl/CouponEventCustomRepositoryImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/impl/CouponEventCustomRepositoryImpl.java
@@ -89,8 +89,7 @@ public class CouponEventCustomRepositoryImpl implements CouponEventCustomReposit
         if(roleCheckIfUser(userRole)) {
             LocalDateTime now = LocalDateTime.now();
 
-            builder.and(couponEvent.eventEndDate.after(now));
-            builder.and(couponEvent.eventStartDate.before(now));
+            builder.and(couponEvent.eventEndDate.after(now).and(couponEvent.eventStartDate.before(now)));
         }
 
         if (startDate != null) {

--- a/coupon/src/main/java/com/haot/coupon/infrastructure/repository/impl/CouponEventCustomRepositoryImpl.java
+++ b/coupon/src/main/java/com/haot/coupon/infrastructure/repository/impl/CouponEventCustomRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.haot.coupon.application.mapper.EventMapper;
 import com.haot.coupon.domain.model.CouponEvent;
 import com.haot.coupon.domain.model.enums.EventStatus;
 import com.haot.coupon.infrastructure.repository.CouponEventCustomRepository;
+import com.haot.submodule.role.Role;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
@@ -38,9 +39,9 @@ public class CouponEventCustomRepositoryImpl implements CouponEventCustomReposit
     );
 
     @Override
-    public Page<EventSearchResponse> searchEventByRole(EventSearchRequest request, Pageable pageable) {
+    public Page<EventSearchResponse> searchEventByRole(Role userRole, EventSearchRequest request, Pageable pageable) {
 
-        BooleanBuilder booleanBuilder = getBooleanBuilder(request);
+        BooleanBuilder booleanBuilder = getBooleanBuilder(userRole, request);
 
         List<CouponEvent> couponEvents = queryFactory
                 .selectFrom(couponEvent)
@@ -68,18 +69,29 @@ public class CouponEventCustomRepositoryImpl implements CouponEventCustomReposit
 
     }
 
-    private BooleanBuilder getBooleanBuilder(EventSearchRequest request) {
+    private BooleanBuilder getBooleanBuilder(Role userRole, EventSearchRequest request) {
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(likeEventName(request.getNameKeyword()));
         builder.and(likeEventDescription(request.getDescriptionKeyword()));
-        builder.and(checkIsDeleted(request.getIsDelete()));
-        builder.and(searchToEventStatus(request.getEventStatus()));
-        builder.and(searchToDate(request.getStartDate(), request.getEndDate()));
+        builder.and(checkIsDeleted(userRole, request.getIsDelete()));
+        builder.and(searchToEventStatus(userRole, request.getEventStatus()));
+        builder.and(searchToDate(userRole, request.getStartDate(), request.getEndDate()));
         return builder;
     }
 
-    private BooleanExpression searchToDate(LocalDateTime startDate, LocalDateTime endDate) {
+    private boolean roleCheckIfUser(Role userRole) {
+        return userRole == Role.USER;
+    }
+
+    private BooleanExpression searchToDate(Role userRole, LocalDateTime startDate, LocalDateTime endDate) {
         BooleanBuilder builder = new BooleanBuilder();
+
+        if(roleCheckIfUser(userRole)) {
+            LocalDateTime now = LocalDateTime.now();
+
+            builder.and(couponEvent.eventEndDate.after(now));
+            builder.and(couponEvent.eventStartDate.before(now));
+        }
 
         if (startDate != null) {
             builder.and(couponEvent.eventStartDate.after(startDate));
@@ -101,11 +113,21 @@ public class CouponEventCustomRepositoryImpl implements CouponEventCustomReposit
         return StringUtils.hasText(eventDescription) ? couponEvent.eventName.containsIgnoreCase(eventDescription.trim()) : null;
     }
 
-    private BooleanExpression checkIsDeleted(Boolean isDeleted) {
+    private BooleanExpression checkIsDeleted(Role userRole, Boolean isDeleted) {
+
+        if(roleCheckIfUser(userRole)){
+            return couponEvent.isDeleted.eq(false);
+        }
+
         return isDeleted == null ? null : couponEvent.isDeleted.eq(isDeleted);
     }
 
-    private BooleanExpression searchToEventStatus(String eventStatus) {
+    private BooleanExpression searchToEventStatus(Role userRole, String eventStatus) {
+
+        if (roleCheckIfUser(userRole)) {
+            return couponEvent.eventStatus.eq(EventStatus.DEFAULT);
+        }
+
         return StringUtils.hasText(eventStatus) ? couponEvent.eventStatus.eq(EventStatus.checkEventStatus(eventStatus)) : null;
     }
 

--- a/coupon/src/main/java/com/haot/coupon/presentation/controller/CouponController.java
+++ b/coupon/src/main/java/com/haot/coupon/presentation/controller/CouponController.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.UUID;
 
 @RestController
@@ -58,8 +59,9 @@ public class CouponController implements CouponControllerDocs {
     // 유효성 검사 API
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/verify")
-    public ApiResponse<ReservationVerifyResponse> verify(@RequestBody FeignVerifyRequest request) {
-        return ApiResponse.SUCCESS(SuccessCode.VERIFY_COUPON_SUCCESS, couponService.verify(request));
+    public ApiResponse<ReservationVerifyResponse> verify(@RequestHeader("X-User-Id") String userId,
+                                                         @RequestBody FeignVerifyRequest request) {
+        return ApiResponse.SUCCESS(SuccessCode.VERIFY_COUPON_SUCCESS, couponService.verify(userId, request));
     }
 
     // 쿠폰 Rollback API
@@ -67,7 +69,7 @@ public class CouponController implements CouponControllerDocs {
     @PutMapping("/{reservationCouponId}/rollback")
     public ApiResponse<Void> rollbackReservationCoupon(@RequestHeader("X-User-Id") String userId,
                                                        @RequestHeader("X-User-Role") Role role,
-                                                       @PathVariable(value = "reservationCouponId") String reservationCouponId){
+                                                       @PathVariable(value = "reservationCouponId") String reservationCouponId) {
 
         couponService.rollbackReservationCoupon(userId, role, reservationCouponId);
         return ApiResponse.SUCCESS(SuccessCode.COUPON_RESERVATION_ROLLBACK_SUCCESS);
@@ -76,7 +78,8 @@ public class CouponController implements CouponControllerDocs {
     // [Feign] 예약 취소 or 확정 API
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{reservationCouponId}")
-    public ApiResponse<Void> confirmReservation(@PathVariable(value = "reservationCouponId") String reservationCouponId,
+    public ApiResponse<Void> confirmReservation(@RequestHeader("X-User-Id") String userId,
+                                                @PathVariable(value = "reservationCouponId") String reservationCouponId,
                                                 @RequestBody FeignConfirmReservationRequest request) {
 
         couponService.confirmReservation(reservationCouponId, request);

--- a/coupon/src/main/java/com/haot/coupon/presentation/controller/EventController.java
+++ b/coupon/src/main/java/com/haot/coupon/presentation/controller/EventController.java
@@ -1,13 +1,13 @@
 package com.haot.coupon.presentation.controller;
 
 import com.haot.coupon.application.dto.request.events.EventSearchRequest;
+import com.haot.coupon.application.dto.response.PageResponse;
 import com.haot.coupon.application.dto.response.events.EventSearchResponse;
 import com.haot.coupon.application.service.EventService;
 import com.haot.coupon.common.response.ApiResponse;
 import com.haot.coupon.common.response.enums.SuccessCode;
 import com.haot.submodule.role.Role;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -29,9 +29,9 @@ public class EventController implements com.haot.coupon.presentation.docs.EventC
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
-    public ApiResponse<Page<EventSearchResponse>> searchEvent(@RequestHeader("X-User-Role") Role userRole,
-                                                              @ModelAttribute EventSearchRequest request,
-                                                              Pageable pageable) {
+    public ApiResponse<PageResponse<EventSearchResponse>> searchEvent(@RequestHeader("X-User-Role") Role userRole,
+                                                                      @ModelAttribute EventSearchRequest request,
+                                                                      Pageable pageable) {
         return ApiResponse.success(eventService.searchEvent(userRole, request, pageable));
     }
 

--- a/coupon/src/main/java/com/haot/coupon/presentation/docs/CouponControllerDocs.java
+++ b/coupon/src/main/java/com/haot/coupon/presentation/docs/CouponControllerDocs.java
@@ -26,11 +26,11 @@ public interface CouponControllerDocs {
     ApiResponse<Void> customerIssueCoupon(String userId, CouponCustomerCreateRequest request);
 
     @Operation(summary = "쿠폰 유효성 검사 API", description = "[Feign] 쿠폰 사용하기 전 유효성 검사 API 입니다.")
-    ApiResponse<ReservationVerifyResponse> verify(FeignVerifyRequest request);
+    ApiResponse<ReservationVerifyResponse> verify(String userId, FeignVerifyRequest request);
 
     @Operation(summary = "쿠폰 rollback API", description = "[Feign] 쿠폰 사용 취소시 쿠폰 사용 Rollback API 입니다.")
     ApiResponse<Void> rollbackReservationCoupon(String userId, Role role, String reservationCouponId);
 
     @Operation(summary = "쿠폰 사용 확정 API", description = "[Feign] 쿠폰 사용 확정하는 API 입니다.")
-    ApiResponse<Void> confirmReservation(String reservationCouponId, FeignConfirmReservationRequest request);
+    ApiResponse<Void> confirmReservation(String userId, String reservationCouponId, FeignConfirmReservationRequest request);
 }

--- a/coupon/src/main/java/com/haot/coupon/presentation/docs/EventControllerDocs.java
+++ b/coupon/src/main/java/com/haot/coupon/presentation/docs/EventControllerDocs.java
@@ -1,12 +1,12 @@
 package com.haot.coupon.presentation.docs;
 
 import com.haot.coupon.application.dto.request.events.EventSearchRequest;
+import com.haot.coupon.application.dto.response.PageResponse;
 import com.haot.coupon.application.dto.response.events.EventSearchResponse;
 import com.haot.coupon.common.response.ApiResponse;
 import com.haot.submodule.role.Role;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 @Tag(name = "이벤트 API Controller", description = "쿠폰 API 목록입니다.")
@@ -16,5 +16,5 @@ public interface EventControllerDocs {
     ApiResponse<EventSearchResponse> getEvent(String eventId);
 
     @Operation(summary = "이벤트 검색 API", description = "이벤트 검색 API 입니다.")
-    ApiResponse<Page<EventSearchResponse>> searchEvent(Role userRole, EventSearchRequest request, Pageable pageable);
+    ApiResponse<PageResponse<EventSearchResponse>> searchEvent(Role userRole, EventSearchRequest request, Pageable pageable);
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
<!-- 반영되는 브런치도 표시해주세요 -->
- closed #186  

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 캐시 적용, 삭제
- 쓰고 있던 isDelete컬럼 삭제 후 BaseEntity isDeleted 컬럼으로 모두 변경
- Custom pageResponse 객체 추가
- QueryDsl 조건 변경

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 캐싱 적용 완료
![스크린샷 2025-01-23 142338](https://github.com/user-attachments/assets/cf38553e-1b6e-4e9b-ac0f-659d2c5d287a)
- 이벤트 생성, 수정 시 캐싱 삭제
![스크린샷 2025-01-23 143447](https://github.com/user-attachments/assets/6221a71e-7d85-4ed9-a90e-6b187a0ea842)
![스크린샷 2025-01-23 143919](https://github.com/user-attachments/assets/2f065339-8805-4db8-a425-24216a6157cb)
- 이벤트 수정 제목, 설명만 바꾸는 거면 캐싱 삭제 X
![스크린샷 2025-01-23 144111](https://github.com/user-attachments/assets/30db7d5a-3d3b-4dd9-8cae-603f1164b2aa)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 이벤트 검색 말고 page 조회만 캐싱되게 하였습니다. 검색 조건마다 캐싱 되는건 아닌 것 같아서요!
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!
